### PR TITLE
fix: remove failing placeholder test

### DIFF
--- a/test/jfr/utils_test.clj
+++ b/test/jfr/utils_test.clj
@@ -6,9 +6,6 @@
 (deftest if-nil-test
   (is (= 1 (if-nil (fn [] nil) #(+ 1) (fn [] 2)))))
 
-(deftest fail
-  (is (= 0 (+ 12 3 434 4 32 4 324 32 4 324))))
-
 (deftest normalize-vector-test
   (is (= [1 2] (normalize-vector [1 2])))
   (is (= [1] (normalize-vector 1))))


### PR DESCRIPTION
## Summary
- drop failing `fail` test from `utils_test`

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c37485efa88327a35f7935b0a5847a