### PR TITLE
Use fedora minimal registry image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/fedora/fedora-minimal:42 AS base
-RUN dnf install -y java-25-openjdk curl
+RUN dnf install -y java-25-openjdk curl tar
 
 FROM base AS clojure
 RUN dnf install -y rlwrap && \


### PR DESCRIPTION
## Summary
- revert to the previous multi-stage Dockerfile layout
- update the base image to quay.io/fedora/fedora-minimal:42 as requested

## Testing
- not run

