### PR TITLE
Fix history list layout and add heapdump + server/logging improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: buildx-cache
+          key: buildx-cache-${{ hashFiles('Dockerfile') }}
+          restore-keys: |
+            buildx-cache-
+          
 
       - name: Prepare Maven cache directory
         run: |
@@ -28,7 +31,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: clojure-m2-cache
+          key: clojure-m2-cache-${{ hashFiles('deps.edn') }}
+          restore-keys: |
+            clojure-m2-cache-
 
       - name: Check Clojure cache before tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ pom.xml.asc
 /.cpcache
 /node_modules
 /storage
-/lib
+!/lib/jolDockerfile
+!/lib/assmble-jol.sh
 
 ### VS Code ###
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ docker compose up --build
 
 ## Testing & quality gate
 - Always run `clj -M:test` before pushing. Tests rely on temporary directories; avoid hard-coding absolute paths.
+- Execute `./prepare-env.sh` before running tests.
 - If you touch the HTTP layer, hit `http://localhost:8080/index.html` manually or via integration tests to confirm multipart uploads still succeed.
 - Ensure any new binaries or large files are ignored via `.gitignore`—only checked-in source/config files should land in commits.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L -O https://github.com/clojure/brew-install/releases/download/1.12.4.
     ./linux-install.sh -p /app/clojure && \
     rm linux-install.sh && \
     mkdir -p /app/lib && \
-    curl -L -o /app/lib/jfr-converter.jar https://github.com/async-profiler/async-profiler/releases/download/v4.2.1/jfr-converter.jar
+    curl -L -o /app/lib/jfr-converter.jar https://github.com/async-profiler/async-profiler/releases/download/v4.3/jfr-converter.jar
 WORKDIR /app
 
 FROM clojure AS builder

--- a/deps.edn
+++ b/deps.edn
@@ -1,19 +1,24 @@
-{:paths ["src/clj" "resources"] 
+{:paths ["src/clj" "resources"]
 
  :deps {org.clojure/clojure {:mvn/version "1.12.4"}
-        http-kit/http-kit {:mvn/version "2.8.1"}
+        aleph/aleph {:mvn/version "0.9.5"}
         compojure/compojure {:mvn/version "1.7.2"}
         one/convert {:local/root "lib/jfr-converter.jar"}
         org.rocksdb/rocksdbjni$linux64 {:mvn/version "10.4.2"}
         org.rocksdb/rocksdbjni$osx {:mvn/version "10.4.2"}
         hiccup/hiccup {:mvn/version "2.0.0"}
-        org.clojure/data.json {:mvn/version "2.5.1"}}
+        org.openjdk.jol/jol-core {:mvn/version "0.17"}
+        org.clojure/data.json {:mvn/version "2.5.2"}
+        org.clojure/tools.logging {:mvn/version "1.3.1"}
+        org.apache.logging.log4j/log4j-slf4j2-impl {:mvn/version "2.25.3"}
+        org.bouncycastle/bcprov-jdk18on {:mvn/version "1.83"}
+        org.bouncycastle/bcpkix-jdk18on {:mvn/version "1.83"}}
 
  :aliases
  {:uberjar {:jvm-opts ["-Dclojure.compiler.direct-linking=true" "--enable-native-access=ALL-UNNAMED"]
             :exec-fn jfr.core/-main
             :exec-args {:compile true}}
-  :repl {:jvm-opts    ["-Xmx8g" "-Xms8g" "-XX:+UnlockDiagnosticVMOptions" "-XX:+DebugNonSafepoints" "-Djdk.attach.allowAttachSelf" "-XX:+EnableDynamicAgentLoading" "--enable-native-access=ALL-UNNAMED"] 
+  :repl {:jvm-opts    ["-Xmx8g" "-Xms8g" "-XX:+UnlockDiagnosticVMOptions" "-XX:+DebugNonSafepoints" "-Djdk.attach.allowAttachSelf" "-XX:+EnableDynamicAgentLoading" "--enable-native-access=ALL-UNNAMED"]
          :extra-paths ["src/repl"]
          :extra-deps {cider/cider-nrepl {:mvn/version "0.58.0"}
                       nrepl/nrepl       {:mvn/version "1.5.1"}
@@ -25,4 +30,6 @@
   :test {:extra-paths ["test"]
          :jvm-opts ["--enable-native-access=ALL-UNNAMED"]
          :extra-deps {org.clojure/tools.namespace {:mvn/version "1.5.0"}}
-         :main-opts ["-m" "test-runner"]}}}
+         :main-opts ["-m" "test-runner"]}
+  :outdated {:replace-deps {olical/depot {:mvn/version "2.4.1"}}
+              :main-opts ["-m" "depot.outdated.main"]}}}

--- a/lib/assmble-jol.sh
+++ b/lib/assmble-jol.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+OUT_DIR="${ROOT_DIR}/lib/"
+
+mkdir -p "${OUT_DIR}"
+
+docker build \
+  --file "${ROOT_DIR}/lib/jolDockerfile" \
+  --target export \
+  --output "type=local,dest=${OUT_DIR}" \
+  "${ROOT_DIR}"
+
+echo "JOL artifacts exported to ${OUT_DIR}"

--- a/lib/jolDockerfile
+++ b/lib/jolDockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM eclipse-temurin:25-jdk AS build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git maven \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/openjdk/jol.git
+
+WORKDIR /src/jol
+RUN mvn -q -DskipTests package \
+    && mkdir -p /out \
+    && cp jol-cli/target/jol-cli.jar /out/ \
+    && cp jol-core/target/jol-core-*.jar /out/ 
+
+FROM scratch AS export
+COPY --from=build /out/ /

--- a/prepare-env.sh
+++ b/prepare-env.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-JFR_ASYNC_PROFILER_VERSION="4.2"
+JFR_ASYNC_PROFILER_VERSION="4.3"
 ASYNC_PROFILER_PLATFORM="linux-x64"
 LIB_DIR="lib"
 CLOJURE_INSTALLER="linux-install.sh"
@@ -10,15 +10,16 @@ CLOJURE_INSTALLER="linux-install.sh"
 JFR_CONVERTER_URL="https://github.com/async-profiler/async-profiler/releases/download/v${JFR_ASYNC_PROFILER_VERSION}/jfr-converter.jar"
 CLOJURE_INSTALLER_URL="https://github.com/clojure/brew-install/releases/latest/download/${CLOJURE_INSTALLER}"
 
-if command -v dnf >/dev/null 2>&1; then
-  echo "Installing rlwrap via dnf"
-  dnf install -y rlwrap
-elif command -v apt-get >/dev/null 2>&1; then
-  echo "Installing rlwrap via apt-get"
-  apt-get update
-  apt-get install -y rlwrap
-else
-  echo "dnf and apt-get not found; skipping rlwrap installation" >&2
+HAS_RLWRAP=false
+HAS_CLJ=false
+HAS_CONVERTER=false
+
+if command -v rlwrap >/dev/null 2>&1; then
+  HAS_RLWRAP=true
+fi
+
+if command -v clj >/dev/null 2>&1; then
+  HAS_CLJ=true
 fi
 
 mkdir -p "${LIB_DIR}"
@@ -28,18 +29,38 @@ if [[ ! -f "${LIB_DIR}/jfr-converter.jar" ]]; then
   curl -fsSL -o "${LIB_DIR}/jfr-converter.jar" "${JFR_CONVERTER_URL}"
 else
   echo "${LIB_DIR}/jfr-converter.jar already exists; skipping download"
+  HAS_CONVERTER=true
 fi
 
-if [[ ! -f "${CLOJURE_INSTALLER}" ]]; then
-  echo "Downloading Clojure installer"
-  curl -fsSL -o "${CLOJURE_INSTALLER}" "${CLOJURE_INSTALLER_URL}"
-else
-  echo "${CLOJURE_INSTALLER} already exists; skipping download"
+if ${HAS_RLWRAP} && ${HAS_CLJ} && ${HAS_CONVERTER}; then
+  echo "Prerequisites already present; nothing to do."
+  exit 0
 fi
 
-chmod +x "${CLOJURE_INSTALLER}"
+if ! ${HAS_RLWRAP}; then
+  if command -v dnf >/dev/null 2>&1; then
+    echo "Installing rlwrap via dnf"
+    dnf install -y rlwrap
+  elif command -v apt-get >/dev/null 2>&1; then
+    echo "Installing rlwrap via apt-get"
+    apt-get update
+    apt-get install -y rlwrap
+  else
+    echo "dnf and apt-get not found; skipping rlwrap installation" >&2
+  fi
+fi
 
-echo "Running Clojure installer"
-"./${CLOJURE_INSTALLER}"
+if ! ${HAS_CLJ}; then
+  if [[ ! -f "${CLOJURE_INSTALLER}" ]]; then
+    echo "Downloading Clojure installer"
+    curl -fsSL -o "${CLOJURE_INSTALLER}" "${CLOJURE_INSTALLER_URL}"
+  else
+    echo "${CLOJURE_INSTALLER} already exists; skipping download"
+  fi
+
+  chmod +x "${CLOJURE_INSTALLER}"
+  echo "Running Clojure installer"
+  "./${CLOJURE_INSTALLER}"
+fi
 
 echo "Environment preparation complete"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,2 +1,5 @@
 {:jfr-data-path "storage/jfrs" 
- :temp-dir "storage/temp"}
+ :temp-dir "storage/temp"
+ :heapdump-print-first 50
+ :server-port 8080
+ :http2? false}

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="[%d{ISO8601}] %-5p %c - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/resources/public/heapdump.html
+++ b/resources/public/heapdump.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <title>Heap Dump Stats</title>
+  <style>
+    :root{--bg:#0b1220;--fg:#e9eef5;--acc:#3b82f6;--mut:#96a0b5}
+    *{box-sizing:border-box}
+    body{margin:0;font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--fg);min-height:100vh;display:flex;justify-content:center;padding:24px}
+    .panel{background:#0f172a;border:1px solid #223;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.3);padding:20px;width:min(1200px,100%);display:flex;flex-direction:column;min-height:calc(100vh - 48px)}
+    h1{margin:0 0 8px;font-size:20px}
+    p{margin:0 0 12px;color:var(--mut)}
+    .row{display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin-top:12px}
+    button{padding:10px 14px;border-radius:10px;border:0;background:var(--acc);color:#fff;cursor:pointer}
+    button.secondary{background:#1f2937;color:var(--fg)}
+    .status{font-size:14px;color:var(--mut)}
+    .output{margin-top:16px;background:#050910;border:1px solid #223;border-radius:12px;padding:14px;white-space:pre-wrap;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;overflow:auto;width:100%;flex:1;min-height:0}
+    progress{width:100%;height:12px;margin-top:10px}
+    a{color:#93c5fd;text-decoration:none}
+    a:hover{text-decoration:underline}
+  </style>
+</head>
+<body>
+  <section class="panel">
+    <h1>Heap Dump Stats (JOL)</h1>
+    <p>Upload a <code>.hprof</code> heap dump and receive the same stats as <code>jol-cli heapdump-stats</code>.</p>
+    <p><a href="/index.html">← Back to JFR merge</a></p>
+
+    <input id="fileInput" type="file" accept=".hprof,.gz" hidden>
+    <div class="row">
+      <button id="pick" class="secondary" type="button">Choose heap dump</button>
+      <button id="send" type="button" disabled>Analyze heap dump</button>
+      <span id="fileName" class="status">No file selected.</span>
+    </div>
+    <progress id="progress" max="100" value="0" hidden></progress>
+    <div id="status" class="status"></div>
+    <pre id="output" class="output" aria-live="polite"></pre>
+  </section>
+
+<script>
+(() => {
+  'use strict';
+  const pickBtn = document.getElementById('pick');
+  const sendBtn = document.getElementById('send');
+  const fileInput = document.getElementById('fileInput');
+  const fileName = document.getElementById('fileName');
+  const status = document.getElementById('status');
+  const output = document.getElementById('output');
+  const progress = document.getElementById('progress');
+
+  let selectedFile = null;
+  let bytesSent = 0;
+
+  const setStatus = (text) => { status.textContent = text; };
+  const resetOutput = () => { output.textContent = ''; };
+  const uploadUrl = () => `${location.origin}/api/heapdump`;
+
+  pickBtn.addEventListener('click', () => fileInput.click());
+  fileInput.addEventListener('change', (event) => {
+    selectedFile = event.target.files[0] || null;
+    if (selectedFile) {
+      fileName.textContent = `${selectedFile.name} (${(selectedFile.size / 1024 / 1024).toFixed(2)} MiB)`;
+      sendBtn.disabled = false;
+    } else {
+      fileName.textContent = 'No file selected.';
+      sendBtn.disabled = true;
+    }
+  });
+
+  const sendHeapdump = async () => {
+    if (!selectedFile) return;
+    resetOutput();
+    progress.hidden = false;
+    progress.value = 0;
+    bytesSent = 0;
+    setStatus('Uploading…');
+
+    const formData = new FormData();
+    formData.append('file', selectedFile, selectedFile.name);
+
+    try {
+      const response = await fetch(uploadUrl(), {
+        method: 'POST',
+        body: formData
+      });
+      progress.value = 100;
+      if (!response.ok) {
+        const message = await response.text();
+        setStatus(`Error: ${message}`);
+        return;
+      }
+      setStatus('Done.');
+      output.textContent = await response.text();
+    } catch (error) {
+      setStatus(`Error: ${error.message || 'Upload failed'}`);
+    }
+  };
+
+  sendBtn.addEventListener('click', sendHeapdump);
+})();
+</script>
+</body>
+</html>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -6,70 +6,52 @@
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>JFR Viewier</title>
   <style>
-    :root{--bg:#0b1220;--fg:#e9eef5;--acc:#3b82f6;--mut:#96a0b5}
-    *{box-sizing:border-box}
-    body{margin:0;font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--fg);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
-    .grid{display:grid;grid-template-columns:1fr 2fr;gap:16px;width:min(1500px,100%)}
-    .panel{background:#0f172a;border:1px solid #223;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.3);padding:18px;min-height:360px}
-    h1{margin:0 0 8px;font-size:20px}
-    p{margin:0 0 12px;color:var(--mut)}
-    .drop{border:2px dashed #334155;border-radius:14px;padding:24px;text-align:center;transition:.15s;user-select:none}
-    .drop.highlight{border-color:var(--acc);background:rgba(59,130,246,.08)}
-    .btns{margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;justify-content:center}
-    button,.ghost{padding:10px 14px;border-radius:10px;border:0;background:var(--acc);color:#fff;cursor:pointer}
-    .ghost{background:#1f2937;color:var(--fg)}
-    ul{list-style:none;padding:0;margin:12px 0 0;overflow:auto}
-    li{display:flex;justify-content:space-between;gap:8px;padding:2px 0;border-bottom:1px dashed #223}
-    small{color:var(--mut)}
-    .row{display:flex;gap:8px;align-items:center;justify-content:center;margin-top:10px}
-    progress{width:100%;height:10px}
+    :root { --bg:#0b1220; --fg:#e9eef5; --acc:#3b82f6; --mut:#96a0b5; }
+    * { box-sizing:border-box; }
+    body { margin:0; font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; background:var(--bg); color:var(--fg); min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px; }
+    .grid { display:grid; grid-template-columns:1fr 2fr; gap:16px; width:min(1500px,100%); }
+    .panel { background:#0f172a; border:1px solid #223; border-radius:14px; padding:18px; min-height:360px; box-shadow:0 6px 16px rgba(0,0,0,.35); }
+    h1 { margin:0 0 8px; font-size:20px; }
+    p { margin:0 0 12px; color:var(--mut); }
 
-    .history{border:2px dashed #334155;border-radius:14px;padding:12px;min-height:360px}
-    .history ol{margin:8px 0 0;padding-left:0px}
-    .history li{display:grid;grid-template-columns:12fr 2fr 1fr 1fr;gap:0px;align-items:start}
-    .history li a{word-break:break-word;text-decoration:none}
-    .history li a:hover{text-decoration:underline}
-    .history-name{cursor:text;min-width:0;display:inline-flex;align-items:center;gap:6px}
-    .history-name[contenteditable="true"]{outline:1px solid var(--acc);border-radius:4px;padding:0 4px}
+    .drop { border:2px dashed #334155; border-radius:12px; padding:20px; text-align:center; transition:border-color .15s, background .15s; user-select:none; }
+    .drop.highlight { border-color:var(--acc); background:rgba(59,130,246,.07); }
+    .btns { margin-top:12px; display:flex; gap:8px; flex-wrap:wrap; justify-content:center; }
+    button, .ghost { padding:10px 14px; border-radius:10px; border:0; background:var(--acc); color:#fff; cursor:pointer; font-weight:600; }
+    .ghost { background:#1f2937; color:var(--fg); }
+    ul { list-style:none; padding:0; margin:12px 0 0; overflow:auto; }
+    li { display:flex; justify-content:space-between; gap:8px; padding:4px 0; border-bottom:1px dashed #223; }
+    small { color:var(--mut); }
+    .row { display:flex; gap:8px; align-items:center; justify-content:space-between; margin-top:10px; }
+    progress { width:100%; height:10px; }
 
-    .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:32px;background:rgba(3,6,17,.85);backdrop-filter:blur(6px);z-index:9999}
-    .modal.is-visible{display:flex}
-    .modal__dialog{background:#0f172a;border:1px solid rgba(59,130,246,.25);border-radius:18px;box-shadow:0 20px 60px rgba(2,6,23,.8);max-width:1200px;width:100%;max-height:85vh;display:flex;flex-direction:column;overflow:hidden}
-    .modal__header{display:flex;align-items:center;justify-content:space-between;padding:20px 24px;border-bottom:1px solid rgba(255,255,255,.08);background:linear-gradient(135deg,rgba(59,130,246,.2),rgba(14,165,233,.05))}
-    .modal__title{margin:0;font-size:18px;font-weight:600;letter-spacing:.01em}
-    .modal__close{border:none;background:rgba(255,255,255,.08);color:var(--fg);width:34px;height:34px;border-radius:50%;font-size:18px;cursor:pointer;transition:background .2s ease;display:flex;align-items:center;justify-content:center}
-    .modal__close:hover{background:rgba(255,255,255,.2)}
-    .modal__body{padding:24px;overflow:auto;font-size:14px;color:var(--fg);line-height:1.6;background:#0b1220;white-space:pre-wrap;}
-    .profiler-report{display:flex;flex-direction:column;gap:18px;color:#f8fbff}
-    .report-header{background:#10172a;border:1px solid rgba(255,255,255,.06);border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:10px}
-    .report-title-row{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:space-between}
-    .report-title{font-size:22px;font-weight:600}
-    .report-uuid{font-size:14px;color:var(--mut);letter-spacing:.02em}
-    .report-meta{display:flex;flex-wrap:wrap;gap:12px;font-size:14px;color:var(--mut)}
-    .report-body{display:flex;flex-direction:column;gap:16px}
-    .report-issues{display:flex;flex-direction:column;gap:18px}
-    .issue{background:#0f172a;border:1px solid rgba(59,130,246,.2);border-radius:16px;padding:18px;box-shadow:0 12px 32px rgba(2,6,23,.5)}
-    .issue-header{display:flex;flex-direction:column;gap:10px;border-bottom:1px solid rgba(255,255,255,.06);padding-bottom:12px;margin-bottom:12px}
-    .issue-title-row{display:flex;align-items:center;justify-content:space-between;gap:12px}
-    .issue-title{font-size:18px;font-weight:600;color:#f1f5f9}
-    .issue-id{font-size:14px;color:var(--mut);}
-    .issue-meta{display:flex;flex-wrap:wrap;gap:10px;font-size:13px;color:var(--mut)}
-    .issue-advice-label{font-weight:600;margin-right:6px}
-    .issue-stacks{margin-top:14px;border:1px solid rgba(255,255,255,.07);border-radius:12px;padding:12px;background:#050910}
-    .issue-stacks summary{cursor:pointer;font-weight:600;color:var(--fg);outline:none}
-    .issue-stack-list{list-style:none;padding:0;margin:10px 0 0;display:flex;flex-direction:column;gap:8px}
-    .issue-stack-item{background:#0b1120;border-radius:10px;padding:10px 12px;display:grid;grid-template-columns:auto 1fr;gap:12px;align-items:flex-start;border:1px solid rgba(255,255,255,.04)}
-    .issue-stack-hits{font-size:11px;color:#60a5fa;text-transform:uppercase;letter-spacing:.12em;background:rgba(59,130,246,.12);border-radius:999px;padding:4px 10px;font-weight:600;line-height:1;white-space:nowrap}
-    .issue-stack-frames{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:4px;min-width:0;background:rgba(5,9,16,.8)}
-    .issue-stack-frame{font-size:12px;color:#cbd5f5;border-radius:8px;padding:1px 8px;display:flex;align-items:center;gap:8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    .issue-stack-frame-code{font-size:12px;background:none;padding:0;border-radius:0;display:block;max-width:100%;word-break:initial;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#f8fafc}
+    .option-toggle { display:flex; gap:8px; align-items:center; justify-content:flex-start; margin-top:10px; color:#cbd5e1; font-size:14px; cursor:pointer; }
+    .option-toggle .flame-label { font-weight:600; }
 
-    .sr-only {position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap;  border: 0;}
-    #addFlamegraph + .flame-label::before { content: "🚫"; margin-right: 6px; }
-    #addFlamegraph:checked + .flame-label::before { content: "🔥"; }
-    #addDetector + .flame-label::before { content: "🚫"; margin-right: 6px; }
-    #addDetector:checked + .flame-label::before { content: "🔍"; }
+    .history { border:2px dashed #334155; border-radius:12px; padding:12px; min-height:360px; display:flex; flex-direction:column; gap:8px; }
+    .history ol { margin:0; padding-left:0; display:flex; flex-direction:column; gap:12px; }
+    .history-item { display:flex; flex-direction:column; gap:8px; padding:10px; border-radius:10px; border:1px solid rgba(255,255,255,.06); background:#0b1120; }
+    .history li a { word-break:break-word; text-decoration:none; color:var(--acc); font-weight:600; }
+    .history li a:hover { text-decoration:underline; }
+    .history-name { cursor:text; min-width:0; display:inline-flex; align-items:center; gap:6px; padding:2px 6px; border-radius:6px; }
+    .history-name[contenteditable="true"] { outline:1px solid var(--acc); background:#0b1220; }
+    .history-head { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+    .history-meta { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+    .history-links { display:flex; gap:10px; flex-wrap:wrap; align-items:center; color:var(--mut); }
 
+    .modal { position:fixed; inset:0; display:none; align-items:center; justify-content:center; padding:32px; background:rgba(0,0,0,.65); z-index:10; }
+    .modal.is-visible { display:flex; }
+    .modal__dialog { background:#0f172a; border:1px solid #223; border-radius:12px; max-width:900px; width:100%; max-height:85vh; display:flex; flex-direction:column; overflow:hidden; }
+    .modal__header { display:flex; align-items:center; justify-content:space-between; padding:14px 18px; border-bottom:1px solid rgba(255,255,255,.08); }
+    .modal__title { margin:0; font-size:18px; font-weight:700; }
+    .modal__close { border:none; background:#1f2937; color:var(--fg); width:34px; height:34px; border-radius:50%; font-size:18px; cursor:pointer; }
+    .modal__body { padding:18px; overflow:auto; font-size:14px; color:var(--fg); line-height:1.6; background:#0b1220; white-space:pre-wrap; }
+
+    .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0, 0, 0, 0); white-space:nowrap; border:0; }
+    #addFlamegraph + .flame-label::before { content:"🚫"; margin-right:6px; }
+    #addFlamegraph:checked + .flame-label::before { content:"🔥"; }
+    #addDetector + .flame-label::before { content:"🚫"; margin-right:6px; }
+    #addDetector:checked + .flame-label::before { content:"🔍"; }
   </style>
 </head>
 <body>
@@ -77,6 +59,7 @@
     <section class="panel" aria-label="File upload">
       <h1>File Upload</h1>
       <p>Drag and drop files or select manually. Upload via <code>fetch</code>.</p>
+      <p><a href="/heapdump.html" style="color:#93c5fd;text-decoration:none;">Heap dump stats (JOL)</a></p>
 
       <input id="fileInput" type="file" name="files" multiple hidden>
 
@@ -87,15 +70,13 @@
           <button type="button" id="send">Send files</button>
         </div>
       </div>
-      <label for="addFlamegraph"
-        style="display:flex;gap:8px;align-items:center;justify-content:flex-start;margin-top:10px;color:#cbd5e1;font-size:14px;cursor:pointer;">
+      <label for="addFlamegraph" class="option-toggle">
         <input id="addFlamegraph" type="checkbox" class="sr-only">
-        <span class="flame-label" style="font-weight:600;">Add flamegraphs</span>
+        <span class="flame-label">Add flamegraphs</span>
       </label>
-      <label for="addDetector"
-        style="display:flex;gap:8px;align-items:center;justify-content:flex-start;margin-top:10px;color:#cbd5e1;font-size:14px;cursor:pointer;">
+      <label for="addDetector" class="option-toggle">
         <input id="addDetector" type="checkbox" class="sr-only">
-        <span class="flame-label" style="font-weight:600;">Add detector</span>
+        <span class="flame-label">Add detector</span>
       </label>
 
       <ul id="list" aria-live="polite"></ul>
@@ -104,7 +85,7 @@
 
     <section class="panel" aria-label="Link history">
       <div class="history">
-        <div class="row" style="justify-content:space-between;margin:0 0 6px 0">
+        <div class="history-head">
           <strong>History</strong>
           <button type="button" id="clear" class="ghost">Clear</button>
         </div>
@@ -326,6 +307,13 @@
     const frag = document.createDocumentFragment();
     arr.forEach(item => {
       const li = document.createElement('li');
+      li.className = 'history-item';
+
+      const metaRow = document.createElement('div');
+      metaRow.className = 'history-meta';
+
+      const linksRow = document.createElement('div');
+      linksRow.className = 'history-links';
 
       const uuidSpan = document.createElement('span');
       const statsString = trimmedStatsTitle(item.stats);
@@ -364,7 +352,8 @@
         ['-cpu', 'cpu'],
         ['-alloc', 'alloc']
       ]);
-      li.append(uuidSpan, ...baseLinks);
+      metaRow.append(uuidSpan);
+      linksRow.append(...baseLinks);
 
       if(item.flame){
         const sep = document.createElement('span');
@@ -375,9 +364,10 @@
           ['-flame-cpu', 'cpu'],
           ['-flame-alloc', 'alloc']
         ]);
-        li.append(sep, ...flameLinks);
+        linksRow.append(sep, ...flameLinks);
       }
 
+      li.append(metaRow, linksRow);
       frag.append(li);
     });
     historyEl.append(frag);

--- a/src/clj/jfr/detector/worker.clj
+++ b/src/clj/jfr/detector/worker.clj
@@ -1,4 +1,5 @@
 (ns jfr.detector.worker
+  (:require [clojure.tools.logging :as log])
   (:import (java.util.concurrent LinkedBlockingQueue TimeUnit)))
 
 (defonce ^LinkedBlockingQueue queue (LinkedBlockingQueue.))
@@ -10,8 +11,7 @@
     (catch InterruptedException _
       (.interrupt (Thread/currentThread)))
     (catch Throwable t
-      (println "Detector task failed:" (.getMessage t))
-      (.printStackTrace t))))
+      (log/error (str "Detector task failed: " (.getMessage t)) t))))
 
 (defn- worker-loop []
   (try
@@ -21,7 +21,7 @@
       (when (some? @worker-thread)
         (recur)))
     (catch InterruptedException e
-      (.printStackTrace e))))
+      (log/warn "Detector worker loop interrupted" e))))
 
 (defn start! []
   (when (nil? @worker-thread)

--- a/src/clj/jfr/environ.clj
+++ b/src/clj/jfr/environ.clj
@@ -1,37 +1,48 @@
 (ns jfr.environ
   (:require [clojure.edn :as edn]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.tools.logging :as log]))
 
-(def config (atom nil))
+(defonce ^:private config (atom nil))
 
 (defn slurp-safe [x]
   (try
-    (when x [(slurp x) (str x)])             
-    (catch Exception _ nil)))                    
+    (when x [(slurp x) (str x)])
+    (catch Exception _ nil)))
 
 (defn file-readable?
   [path]
-  (let [f (io/file path)]         
-    (and (.exists f)                
-         (.isFile f)          
+  (let [f (io/file path)]
+    (and (.exists f)
+         (.isFile f)
          (.canRead f))))
 
 
 (defn- load-config []
-  (let [[config path] (or
-                     (when-let [name "./config.edn"] (file-readable? name) (slurp-safe (io/file name)))
-                     (when-let [name "./resources/config.edn"] (file-readable? name) (slurp-safe (io/file name)))
-                     (when-let [u (io/resource "config.edn")] (slurp-safe u)))]
-    (println "Loading config from" path)
-    (if (some? config)
-      (edn/read-string config)
-      [])))
+  (let [candidates (concat (for [path ["./config.edn" "./resources/config.edn"]
+                                 :when (file-readable? path)]
+                             (io/file path))
+                           [(io/resource "config.edn")])
+        [raw path] (some slurp-safe candidates)]
+    (when path
+      (log/info (str "Loading config from " path))
+    (if raw
+      (edn/read-string raw)
+      {}))))
 
-(defn- get-property
-  ([key] (when (nil? @config) (reset! config (load-config))) (get @config key))
-  ([key & xs] (when (nil? @config) (reset! config (load-config)))
-   (get-in @config (concat [key] xs))))
+(defn reload-config! []
+  (reset! config (load-config)))
+
+(defn- get-property [key] 
+  (get (or @config (reset! config (load-config))) key))
 
 (defn get-jfr-data-path [] (.getAbsolutePath (java.io.File. (get-property :jfr-data-path))))
 (defn temp-dir [] (get-property :temp-dir))
-
+(defn get-heapdump-print-first [] (get-property :heapdump-print-first))
+(defn get-server-port [] (get-property :server-port))
+(defn get-server-http2? [] (get-property :http2?))
+(defn get-vm-version []
+  (try
+    (Integer/parseInt (System/getProperty "java.specification.version"))
+    (catch Exception _
+      8)))

--- a/src/clj/jfr/heapdump.clj
+++ b/src/clj/jfr/heapdump.clj
@@ -1,0 +1,114 @@
+(ns jfr.heapdump
+  (:require
+   [clojure.java.io :as io]
+   [jfr.environ :as env])
+  (:import
+   (java.util UUID)
+   (java.io File PrintWriter StringWriter)
+   (org.openjdk.jol.datamodel ModelVM)
+   (org.openjdk.jol.heap HeapDumpReader)
+   (org.openjdk.jol.layouters HotSpotLayouter)))
+
+(def ^:private column-order [:instances :size :sum-size])
+
+(def ^:private column-labels
+  {:instances "INSTANCES"
+   :size "SIZE"
+   :sum-size "SUM SIZE"
+   :class "CLASS"})
+
+(defn- format-row [^PrintWriter pw row]
+  (doseq [key column-order]
+    (.print pw (format " %,15d" (long (get row key)))))
+  (.print pw (format "    %s%n" (str (:class row)))))
+
+(defn- sum-columns [rows]
+  (reduce (fn [acc row]
+            (reduce (fn [inner key]
+                      (update inner key + (get row key)))
+                    acc
+                    column-order))
+          {:instances 0 :size 0 :sum-size 0}
+          rows))
+
+(defn- print-table
+  [^PrintWriter pw rows sort-key]
+  (let [sorted-rows (if (= sort-key :class)
+                      (sort-by :class rows)
+                      (sort-by sort-key #(compare %2 %1) rows))
+        print-first (env/get-heapdump-print-first)
+        [head tail] (split-at print-first sorted-rows)
+        tops (sum-columns head)
+        sums (sum-columns sorted-rows)]
+    (.println pw (str "=== Class Histogram. Printing first " print-first " lines."))
+    (.println pw)
+    (.println pw (format "Table is sorted by \"%s\"."
+                         (get column-labels sort-key)))
+    (.println pw)
+    (doseq [key column-order]
+      (.print pw (format " %15s" (get column-labels key))))
+    (.println pw "    CLASS")
+    (.println pw "------------------------------------------------------------------------------------------------")
+    (doseq [row head]
+      (format-row pw row))
+    (when (seq tail)
+      (doseq [_ column-order]
+        (.print pw (format " %15s" "...")))
+      (.print pw "    ...\n")
+      (doseq [key column-order]
+        (.print pw (format " %,15d" (long (- (get sums key) (get tops key))))))
+      (.print pw "    <other>\n"))
+    (.println pw "------------------------------------------------------------------------------------------------")
+    (doseq [key column-order]
+      (.print pw (format " %,15d" (long (get sums key)))))
+    (.print pw "    <total>\n")
+    (.println pw)))
+
+(defn heapdump-stats-text
+  "Return the jol-cli heapdump-stats output for the provided heap dump."
+  [path]
+  (let [layouter (HotSpotLayouter. (ModelVM.) (env/get-vm-version))
+        writer (StringWriter.)
+        pw (PrintWriter. writer)]
+    (.println pw (str "Heap Dump: " path))
+    (let [reader (HeapDumpReader. (io/file path))
+          data (.parse reader)
+          rows (for [cd (.keys data)
+                     :let [cnt (.count data cd)]
+                     :when (pos? cnt)
+                     :let [instance-size (-> layouter (.layout cd) (.instanceSize))]]
+                 {:class (let [name (.name cd)] (if (.isArray cd) (str (subs name 0 (dec (count name))) (.arrayLength cd) "]") name))
+                  :instances (long cnt)
+                  :size (long instance-size)
+                  :sum-size (long (* cnt instance-size))})]
+      (.println pw)
+      (.println pw (.toString layouter))
+      (.println pw)
+      (print-table pw rows :instances)
+      (print-table pw rows :size)
+      (print-table pw rows :sum-size))
+    (.flush pw)
+    (.toString writer)))
+
+(defn- safe-filename [filename]
+  (str (UUID/randomUUID) (if (.endsWith filename ".gz") ".hprof.gz" ".hprof")))
+
+(defn handle-heapdump-upload [{:keys [params]}]
+  (let [file-param (get params "file")
+        tempfile (:tempfile file-param)
+        filename (:filename file-param)]
+    (if (and tempfile filename)
+      (let [temp-dir (env/temp-dir)
+            safe-name (safe-filename filename)
+            path (str temp-dir "/" safe-name)]
+        (io/make-parents path)
+        (try
+          (with-open [in (io/input-stream tempfile)
+                      out (io/output-stream path)]
+            (io/copy in out))
+          (heapdump-stats-text path)
+          (finally
+            (when path
+              (.delete (File. path))))))
+      (throw (IllegalArgumentException. "Missing heapdump file")))))
+

--- a/src/clj/jfr/storage.clj
+++ b/src/clj/jfr/storage.clj
@@ -1,7 +1,8 @@
 (ns jfr.storage
   (:import (org.rocksdb RocksDB Options CompressionType))
   (:require [jfr.environ :as env]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.tools.logging :as log]))
 
 (RocksDB/loadLibrary)
 
@@ -17,7 +18,7 @@
                     (.setMinBlobSize (long (* 512 1024)))
                     (.setBlobCompressionType CompressionType/ZSTD_COMPRESSION))
           db-path (get-db-path)]
-      (println "Opening RocksDB at" db-path)
+      (log/info (str "Opening RocksDB at " db-path))
       (io/make-parents db-path)
       (reset! db-atom (RocksDB/open options db-path)))))
 
@@ -45,7 +46,7 @@
   (let [options (Options.)
         db-path (get-db-path)]
     (RocksDB/destroyDB db-path options)
-    (println "Database" db-path "was deleted")))
+    (log/info (str "Database " db-path " was deleted"))))
 
 (defn stats []
   (when-let [db @db-atom]

--- a/src/clj/jfr/utils.clj
+++ b/src/clj/jfr/utils.clj
@@ -1,12 +1,20 @@
-(ns  jfr.utils
+(ns jfr.utils
   (:import (java.time Instant ZonedDateTime ZoneOffset)))
 
-(defn if-nil [f & ns]
-  (let [v (f)]
-    (cond
-      (not (nil? v)) v
-      (some? ns) (apply if-nil ns)
-      :else v)))
+(defn if-nil
+  "Invokes each thunk in order and returns the first non-nil result.
+  Returns nil when every thunk yields nil."
+  ([f]
+   (f))
+  ([f & fs]
+   (loop [current f
+          remaining fs]
+     (let [value (current)]
+       (if (nil? value)
+         (if-let [next-fn (first remaining)]
+           (recur next-fn (rest remaining))
+           nil)
+         value)))))
 
 (defn normalize-vector [v]
   (if (vector? v) v [v]))

--- a/src/repl/repl.clj
+++ b/src/repl/repl.clj
@@ -1,29 +1,34 @@
 (ns repl
   (:require
    [jfr.core :as core]
+   [jfr.environ :as env]
    [jfr.detector.detector :as detector]
    [jfr.detector.report :as report]
-   [hiccup2.core :as h])
+   [hiccup2.core :as h]
+   [clojure.tools.logging :as log])
   (:import [java.lang NullPointerException]))
 
 
 (core/stop-server)
 (core/-main)
 
-(.printStackTrace (new NullPointerException))
+(env/reload-config!)
+
+(log/error "Simulated NullPointerException" (NullPointerException.))
 
 (defn test-detect []
   (let [;; jfr "test/BadPatternsDemo.jfr"
         jfr "test/SmallBadPatternsDemo.jfr"
         hits (detector/detect-patterns {:jfr-path jfr :alloc-only? false})
-        _ (println "Detected hits:" (count hits))
+        _ (log/info (str "Detected hits: " (count hits)))
         summary (detector/summarize hits {:top-stacks 30})]
-    (println "== Quick-fix patterns in" jfr)
+    (log/info (str "== Quick-fix patterns in " jfr))
     (doseq [{:keys [id title count alloc-bytes top-stacks advice]} summary]
-      (println "\n--" id ":" title)
-      (println "   matches:" count (if (some? alloc-bytes) (str "  alloc-bytes≈" alloc-bytes) ""))
-      (println "   advice: " advice)
-      (println " " top-stacks))))
+      (log/info (str "\n-- " id " : " title))
+      (log/info (str "   matches: " count
+                     (if (some? alloc-bytes) (str "  alloc-bytes≈" alloc-bytes) "")))
+      (log/info (str "   advice: " advice))
+      (log/info (str " " top-stacks)))))
 
 (test-detect)
 
@@ -31,7 +36,7 @@
   (let [;; jfr "test/BadPatternsDemo.jfr"
         jfr "test/SmallBadPatternsDemo.jfr"
         hits (detector/detect-patterns {:jfr-path jfr :alloc-only? false})
-        _ (println "Detected hits:" (count hits))
+        _ (log/info (str "Detected hits: " (count hits)))
         summary (detector/summarize hits {:top-stacks 30})]
     (report/report-div {:uuid "test-uuid-1234"
                         :status "completed"

--- a/test/BadPatternsDemo.java
+++ b/test/BadPatternsDemo.java
@@ -4,11 +4,14 @@ import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class BadPatternsDemo {
 
     // Volatile "black hole" so that results are not eliminated by JIT/GC
     public static volatile Object SINK;
+    private static final Logger LOGGER = LogManager.getLogger(BadPatternsDemo.class);
 
     enum Color {
         RED, GREEN, BLUE, YELLOW, BLACK
@@ -16,11 +19,11 @@ public class BadPatternsDemo {
 
     public static void main(String[] args) throws Exception {
         int iters = args.length > 0 ? Integer.parseInt(args[0]) : 10_000;
-        System.out.println("warmup...");
+        LOGGER.info("warmup...");
         exec(500_000); // warmup
         Thread.sleep(10_000);
         for (int i = 0; i < 1; i++) {
-            System.out.println("Running bad patterns with iterations[" + i + "] = " + iters);
+            LOGGER.info("Running bad patterns with iterations[{}] = {}", i, iters);
             exec(iters);
             Thread.sleep(5_000);
         }
@@ -57,7 +60,7 @@ public class BadPatternsDemo {
         Thread.sleep(1_000);
         badToCharArray(iters);
 
-        System.out.println("Done. SINK=" + (SINK == null ? "null" : SINK.hashCode()));
+        LOGGER.info("Done. SINK={}", SINK == null ? "null" : SINK.hashCode());
     }
 
     // 1) Enum.values() → each call clones the array (Enum.clone visible in stack)

--- a/test/jfr/core_test.clj
+++ b/test/jfr/core_test.clj
@@ -1,5 +1,9 @@
 (ns jfr.core-test
-  (:require [clojure.test :refer :all]
+  (:import [java.io File]
+           [java.util UUID])
+  (:require [aleph.http :as http]
+            [clojure.test :refer :all]
+            [jfr.environ :as env]
             [jfr.core :as core]))
 
 (deftest index-html-served
@@ -11,3 +15,33 @@
                (slurp body))]
     (is (= 200 (:status response)))
     (is (seq text))))
+
+(deftest start-stop-server
+  (with-redefs [env/get-jfr-data-path (fn [] (.getAbsolutePath (File. (str "target/jfr-test-db-" (UUID/randomUUID)))))]
+    (let [original-server @core/server
+          port 8181
+          url (str "https://localhost:" port "/index.html")
+          pool (http/connection-pool {:connection-options {:http-versions [:http2] :force-h2c? true :insecure? true}})
+          request-opts {:pool pool :throw-exceptions false}]
+      (try
+        (core/start-server port true)
+        (is (some? @core/server))
+        (loop [attempts 10]
+          (let [response (try
+                           @(http/get url request-opts)
+                           (catch Exception _ nil))]
+            (cond
+              (and response (= 200 (:status response))) (let [body (:body response)
+                                                              text (if (string? body) body (slurp body))] 
+                                                          (is (seq text)))
+              (zero? attempts) (is false (str "Unexpected status: " (when response (:status response))))
+
+              :else (do
+                      (Thread/sleep 100)
+                      (recur (dec attempts))))))
+        (catch Exception e
+          (is false (str "Unexpected exception: " e)))
+        (finally
+          (core/stop-server)
+          (is (nil? @core/server))
+          (reset! core/server original-server))))))

--- a/test/jfr/heapdump_test.clj
+++ b/test/jfr/heapdump_test.clj
@@ -1,0 +1,31 @@
+(ns jfr.heapdump-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is]]
+   [jfr.heapdump :as heapdump])
+  (:import
+   (com.sun.management HotSpotDiagnosticMXBean)
+   (java.lang.management ManagementFactory)
+   (java.nio.file Files)))
+
+(defn- ^HotSpotDiagnosticMXBean hotspot-diagnostic []
+  (ManagementFactory/newPlatformMXBeanProxy
+   (ManagementFactory/getPlatformMBeanServer)
+   "com.sun.management:type=HotSpotDiagnostic"
+   HotSpotDiagnosticMXBean))
+
+(deftest heapdump-stats-text-from-dump
+  (let [temp-dir (Files/createTempDirectory "jfr-heapdump-test"
+                                            (make-array java.nio.file.attribute.FileAttribute 0))
+        path (-> (.resolve temp-dir "dump.hprof")
+                 (.toFile)
+                 (.getAbsolutePath))]
+    (try
+      (.dumpHeap (hotspot-diagnostic) path true)
+      (let [output (heapdump/heapdump-stats-text path)]
+        (is (string? output))
+        (is (.contains output "Heap Dump:"))
+        (is (.contains output "=== Class Histogram")))
+      (finally
+        (io/delete-file path true)
+        (io/delete-file (.toFile temp-dir) true)))))

--- a/test/jfr/utils_test.clj
+++ b/test/jfr/utils_test.clj
@@ -1,10 +1,19 @@
 (ns jfr.utils-test
   (:require [clojure.test :refer :all]
-            [jfr.core :refer :all]
             [jfr.utils :refer :all]))
 
 (deftest if-nil-test
-  (is (= 1 (if-nil (fn [] nil) #(+ 1) (fn [] 2)))))
+  (is (= 1 (if-nil (constantly nil)
+                   (constantly 1)
+                   (constantly 2))))
+  (is (= :value (if-nil (constantly :value))))
+  (is (nil? (if-nil (constantly nil))))
+  (is (false? (if-nil (constantly nil) (constantly false))))
+  (let [calls (atom 0)]
+    (is (= :ok (if-nil (constantly nil)
+                         (fn [] (swap! calls inc) :ok)
+                         (fn [] (swap! calls dec) :should-not-run))))
+    (is (= 1 @calls))))
 
 (deftest normalize-vector-test
   (is (= [1 2] (normalize-vector [1 2])))

--- a/test/test_runner.clj
+++ b/test/test_runner.clj
@@ -1,12 +1,13 @@
 (ns test-runner
   (:require [clojure.test :as t]
             [clojure.tools.namespace.find :as ns-find]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.tools.logging :as log]))
 
 (defn -main [& _]
   (let [dirs [(io/file "test")]
         nss (ns-find/find-namespaces-in-dir (first dirs))]
-    (println "Running tests in namespaces:" nss)
+    (log/infof "Running tests in namespaces: %s" (vec nss))
     (apply require nss)
     (let [{:keys [fail error]} (apply t/run-tests nss)]
       (shutdown-agents)


### PR DESCRIPTION
### Motivation
- Fix a collapsing/broken history list layout in the SPA so stored links render as distinct, readable cards. 
- Add heap dump analysis support (JOL) to let users upload `.hprof` files and get class-histogram-style stats. 
- Improve server lifecycle, observability and environment tooling to make local development and CI more robust.

### Description
- Rebuilt history markup and styles in `resources/public/index.html` to use `.history-item`, `.history-meta` and `.history-links` rows to prevent stacking issues and improve spacing. 
- Added JOL-based heapdump support via a new namespace `jfr.heapdump` and a static UI at `resources/public/heapdump.html`, plus a `POST /api/heapdump` handler wired in `jfr.core`. 
- Migrated the server from `http-kit` to `aleph` and introduced `start-server`/`stop-server` helpers with optional HTTP/2 and a self-signed SSL context, plus safer lifecycle wiring in `jfr.core` and `jfr.environ`. 
- Switched to structured logging with `clojure.tools.logging` and shipped a basic `resources/log4j2.xml`, updated `deps.edn`, added JOL packaging helpers (`lib/jolDockerfile`, `lib/assmble-jol.sh`), updated `prepare-env.sh` for idempotency, and bumped async-profiler references to `4.3` in the Dockerfile/README. 
- Miscellaneous refactors and fixes including `jfr.utils/if-nil` behavior, improved RocksDB logs in `jfr.storage`, detector-worker logging, and several test additions/adjustments.

### Testing
- Ran the full test suite with `clj -M:test`, which executed 14 tests (36 assertions) and completed with `0 failures, 0 errors`. 
- Performed a lightweight UI check by serving `resources/public` and capturing a screenshot to verify the updated history layout. 
- Added unit/integration tests for heapdump (`test/jfr/heapdump_test.clj`) and server start/stop behavior which ran successfully during the test run.
