### PR TITLE
Tighten history list spacing

### DIFF
--- a/resources/public/heapdump.html
+++ b/resources/public/heapdump.html
@@ -6,20 +6,84 @@
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Heap Dump Stats</title>
   <style>
-    :root{--bg:#0b1220;--fg:#e9eef5;--acc:#3b82f6;--mut:#96a0b5}
-    *{box-sizing:border-box}
-    body{margin:0;font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--fg);min-height:100vh;display:flex;justify-content:center;padding:24px}
-    .panel{background:#0f172a;border:1px solid #223;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.3);padding:20px;width:min(1200px,100%);display:flex;flex-direction:column;min-height:calc(100vh - 48px)}
-    h1{margin:0 0 8px;font-size:20px}
-    p{margin:0 0 12px;color:var(--mut)}
-    .row{display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin-top:12px}
-    button{padding:10px 14px;border-radius:10px;border:0;background:var(--acc);color:#fff;cursor:pointer}
-    button.secondary{background:#1f2937;color:var(--fg)}
-    .status{font-size:14px;color:var(--mut)}
-    .output{margin-top:16px;background:#050910;border:1px solid #223;border-radius:12px;padding:14px;white-space:pre-wrap;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;overflow:auto;width:100%;flex:1;min-height:0}
-    progress{width:100%;height:12px;margin-top:10px}
-    a{color:#93c5fd;text-decoration:none}
-    a:hover{text-decoration:underline}
+    :root {
+      --bg: #0b1220;
+      --fg: #e9eef5;
+      --acc: #3b82f6;
+      --mut: #96a0b5;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font: 16px/1.45 system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      padding: 24px;
+    }
+
+    h1 { margin: 0 0 8px; font-size: 20px; }
+    p { margin: 0 0 12px; color: var(--mut); }
+
+    .panel {
+      background: #0f172a;
+      border: 1px solid #223;
+      border-radius: 16px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+      padding: 20px;
+      width: min(1200px, 100%);
+      display: flex;
+      flex-direction: column;
+      min-height: calc(100vh - 48px);
+    }
+
+    .row {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-top: 12px;
+    }
+
+    button {
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 0;
+      background: var(--acc);
+      color: #fff;
+      cursor: pointer;
+    }
+
+    button.secondary {
+      background: #1f2937;
+      color: var(--fg);
+    }
+
+    .status { font-size: 14px; color: var(--mut); }
+
+    .output {
+      margin-top: 16px;
+      background: #050910;
+      border: 1px solid #223;
+      border-radius: 12px;
+      padding: 14px;
+      white-space: pre-wrap;
+      font-family: ui-monospace, monospace;
+      font-size: 13px;
+      overflow: auto;
+      width: 100%;
+      flex: 1;
+      min-height: 0;
+    }
+
+    progress { width: 100%; height: 12px; margin-top: 10px; }
+
+    a { color: #93c5fd; text-decoration: none; }
+    a:hover { text-decoration: underline; }
   </style>
 </head>
 <body>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -145,8 +145,8 @@
       display: grid;
       grid-template-columns: 12fr 2fr 1fr 1fr;
       align-items: start;
-      padding: 0;
-      line-height: 1.1;
+      padding: 10px 0 12px 0;
+      line-height: 0.8;
     }
 
     .history li a { word-break: break-word; text-decoration: none; }
@@ -686,7 +686,7 @@
       const uuidSpan = document.createElement('span');
       const statsString = trimmedStatsTitle(item.stats);
       uuidSpan.title = statsString;
-      uuidSpan.style.fontSize = '16px';
+      uuidSpan.style.fontSize = '15px';
       uuidSpan.style.fontWeight = 'bold';
       uuidSpan.style.display = 'inline-flex';
       uuidSpan.style.alignItems = 'center';

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -146,7 +146,7 @@
       grid-template-columns: 12fr 2fr 1fr 1fr;
       align-items: start;
       padding: 0;
-      line-height: 1.2;
+      line-height: 1.1;
     }
 
     .history li a { word-break: break-word; text-decoration: none; }

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -6,70 +6,427 @@
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>JFR Viewier</title>
   <style>
-    :root{--bg:#0b1220;--fg:#e9eef5;--acc:#3b82f6;--mut:#96a0b5}
-    *{box-sizing:border-box}
-    body{margin:0;font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--fg);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
-    .grid{display:grid;grid-template-columns:1fr 2fr;gap:16px;width:min(1500px,100%)}
-    .panel{background:#0f172a;border:1px solid #223;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.3);padding:18px;min-height:360px}
-    h1{margin:0 0 8px;font-size:20px}
-    p{margin:0 0 12px;color:var(--mut)}
-    .drop{border:2px dashed #334155;border-radius:14px;padding:24px;text-align:center;transition:.15s;user-select:none}
-    .drop.highlight{border-color:var(--acc);background:rgba(59,130,246,.08)}
-    .btns{margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;justify-content:center}
-    button,.ghost{padding:10px 14px;border-radius:10px;border:0;background:var(--acc);color:#fff;cursor:pointer}
-    .ghost{background:#1f2937;color:var(--fg)}
-    ul{list-style:none;padding:0;margin:12px 0 0;overflow:auto}
-    li{display:flex;justify-content:space-between;gap:8px;padding:2px 0;border-bottom:1px dashed #223}
-    small{color:var(--mut)}
-    .row{display:flex;gap:8px;align-items:center;justify-content:center;margin-top:10px}
-    progress{width:100%;height:10px}
+    :root {
+      --bg: #0b1220;
+      --fg: #e9eef5;
+      --acc: #3b82f6;
+      --mut: #96a0b5;
+    }
 
-    .history{border:2px dashed #334155;border-radius:14px;padding:12px;min-height:360px}
-    .history ol{margin:8px 0 0;padding-left:0px}
-    .history li{display:grid;grid-template-columns:12fr 2fr 1fr 1fr;gap:0px;align-items:start}
-    .history li a{word-break:break-word;text-decoration:none}
-    .history li a:hover{text-decoration:underline}
-    .history-name{cursor:text;min-width:0;display:inline-flex;align-items:center;gap:6px}
-    .history-name[contenteditable="true"]{outline:1px solid var(--acc);border-radius:4px;padding:0 4px}
+    * { box-sizing: border-box; }
 
-    .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:32px;background:rgba(3,6,17,.85);backdrop-filter:blur(6px);z-index:9999}
-    .modal.is-visible{display:flex}
-    .modal__dialog{background:#0f172a;border:1px solid rgba(59,130,246,.25);border-radius:18px;box-shadow:0 20px 60px rgba(2,6,23,.8);max-width:1200px;width:100%;max-height:85vh;display:flex;flex-direction:column;overflow:hidden}
-    .modal__header{display:flex;align-items:center;justify-content:space-between;padding:20px 24px;border-bottom:1px solid rgba(255,255,255,.08);background:linear-gradient(135deg,rgba(59,130,246,.2),rgba(14,165,233,.05))}
-    .modal__title{margin:0;font-size:18px;font-weight:600;letter-spacing:.01em}
-    .modal__close{border:none;background:rgba(255,255,255,.08);color:var(--fg);width:34px;height:34px;border-radius:50%;font-size:18px;cursor:pointer;transition:background .2s ease;display:flex;align-items:center;justify-content:center}
-    .modal__close:hover{background:rgba(255,255,255,.2)}
-    .modal__body{padding:24px;overflow:auto;font-size:14px;color:var(--fg);line-height:1.6;background:#0b1220;white-space:pre-wrap;}
-    .profiler-report{display:flex;flex-direction:column;gap:18px;color:#f8fbff}
-    .report-header{background:#10172a;border:1px solid rgba(255,255,255,.06);border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:10px}
-    .report-title-row{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:space-between}
-    .report-title{font-size:22px;font-weight:600}
-    .report-uuid{font-size:14px;color:var(--mut);letter-spacing:.02em}
-    .report-meta{display:flex;flex-wrap:wrap;gap:12px;font-size:14px;color:var(--mut)}
-    .report-body{display:flex;flex-direction:column;gap:16px}
-    .report-issues{display:flex;flex-direction:column;gap:18px}
-    .issue{background:#0f172a;border:1px solid rgba(59,130,246,.2);border-radius:16px;padding:18px;box-shadow:0 12px 32px rgba(2,6,23,.5)}
-    .issue-header{display:flex;flex-direction:column;gap:10px;border-bottom:1px solid rgba(255,255,255,.06);padding-bottom:12px;margin-bottom:12px}
-    .issue-title-row{display:flex;align-items:center;justify-content:space-between;gap:12px}
-    .issue-title{font-size:18px;font-weight:600;color:#f1f5f9}
-    .issue-id{font-size:14px;color:var(--mut);}
-    .issue-meta{display:flex;flex-wrap:wrap;gap:10px;font-size:13px;color:var(--mut)}
-    .issue-advice-label{font-weight:600;margin-right:6px}
-    .issue-stacks{margin-top:14px;border:1px solid rgba(255,255,255,.07);border-radius:12px;padding:12px;background:#050910}
-    .issue-stacks summary{cursor:pointer;font-weight:600;color:var(--fg);outline:none}
-    .issue-stack-list{list-style:none;padding:0;margin:10px 0 0;display:flex;flex-direction:column;gap:8px}
-    .issue-stack-item{background:#0b1120;border-radius:10px;padding:10px 12px;display:grid;grid-template-columns:auto 1fr;gap:12px;align-items:flex-start;border:1px solid rgba(255,255,255,.04)}
-    .issue-stack-hits{font-size:11px;color:#60a5fa;text-transform:uppercase;letter-spacing:.12em;background:rgba(59,130,246,.12);border-radius:999px;padding:4px 10px;font-weight:600;line-height:1;white-space:nowrap}
-    .issue-stack-frames{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:4px;min-width:0;background:rgba(5,9,16,.8)}
-    .issue-stack-frame{font-size:12px;color:#cbd5f5;border-radius:8px;padding:1px 8px;display:flex;align-items:center;gap:8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    .issue-stack-frame-code{font-size:12px;background:none;padding:0;border-radius:0;display:block;max-width:100%;word-break:initial;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#f8fafc}
+    body {
+      margin: 0;
+      font: 16px/1.45 system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
 
-    .sr-only {position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap;  border: 0;}
+    h1 { margin: 0 0 8px; font-size: 20px; }
+    p { margin: 0 0 12px; color: var(--mut); }
+    small { color: var(--mut); }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 2fr;
+      gap: 16px;
+      width: min(1500px, 100%);
+    }
+
+    .panel {
+      background: #0f172a;
+      border: 1px solid #223;
+      border-radius: 16px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+      padding: 18px;
+      min-height: 360px;
+    }
+
+    .link-muted {
+      color: #93c5fd;
+      text-decoration: none;
+    }
+
+    .drop {
+      border: 2px dashed #334155;
+      border-radius: 14px;
+      padding: 24px;
+      text-align: center;
+      transition: 0.15s;
+      user-select: none;
+    }
+
+    .drop.highlight {
+      border-color: var(--acc);
+      background: rgba(59, 130, 246, 0.08);
+    }
+
+    .btns {
+      margin-top: 12px;
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    button,
+    .ghost {
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 0;
+      background: var(--acc);
+      color: #fff;
+      cursor: pointer;
+    }
+
+    .ghost {
+      background: #1f2937;
+      color: var(--fg);
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 12px 0 0;
+      overflow: auto;
+    }
+
+    li {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 2px 0;
+      border-bottom: 1px dashed #223;
+    }
+
+    .row {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: center;
+      margin-top: 10px;
+    }
+
+    progress { width: 100%; height: 10px; }
+
+    .option-toggle {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: flex-start;
+      margin-top: 10px;
+      color: #cbd5e1;
+      font-size: 14px;
+      cursor: pointer;
+    }
+
+    .flame-label { font-weight: 600; }
+
+    .history {
+      border: 2px dashed #334155;
+      border-radius: 14px;
+      padding: 12px;
+      min-height: 360px;
+    }
+
+    .history-header {
+      justify-content: space-between;
+      margin: 0 0 6px 0;
+    }
+
+    .history ol { margin: 8px 0 0; padding-left: 0; }
+
+    .history li {
+      display: grid;
+      grid-template-columns: 12fr 2fr 1fr 1fr;
+      align-items: start;
+      padding: 0;
+      line-height: 1.2;
+    }
+
+    .history li a { word-break: break-word; text-decoration: none; }
+    .history li a:hover { text-decoration: underline; }
+
+    .history-name {
+      cursor: text;
+      min-width: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .history-name[contenteditable="true"] {
+      outline: 1px solid var(--acc);
+      border-radius: 4px;
+      padding: 0 4px;
+    }
+
+    .modal {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 32px;
+      background: rgba(3, 6, 17, 0.85);
+      backdrop-filter: blur(6px);
+      z-index: 9999;
+    }
+
+    .modal.is-visible { display: flex; }
+
+    .modal__dialog {
+      background: #0f172a;
+      border: 1px solid rgba(59, 130, 246, 0.25);
+      border-radius: 18px;
+      box-shadow: 0 20px 60px rgba(2, 6, 23, 0.8);
+      max-width: 1200px;
+      width: 100%;
+      max-height: 85vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .modal__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 24px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      background: linear-gradient(
+        135deg,
+        rgba(59, 130, 246, 0.2),
+        rgba(14, 165, 233, 0.05)
+      );
+    }
+
+    .modal__title {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }
+
+    .modal__close {
+      border: none;
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--fg);
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      font-size: 18px;
+      cursor: pointer;
+      transition: background 0.2s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .modal__close:hover { background: rgba(255, 255, 255, 0.2); }
+
+    .modal__body {
+      padding: 24px;
+      overflow: auto;
+      font-size: 14px;
+      color: var(--fg);
+      line-height: 1.6;
+      background: #0b1220;
+      white-space: pre-wrap;
+    }
+
+    .profiler-report {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      color: #f8fbff;
+    }
+
+    .report-header {
+      background: #10172a;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 14px;
+      padding: 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .report-title-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .report-title { font-size: 22px; font-weight: 600; }
+    .report-uuid { font-size: 14px; color: var(--mut); letter-spacing: 0.02em; }
+
+    .report-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 14px;
+      color: var(--mut);
+    }
+
+    .report-body {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .report-issues {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .issue {
+      background: #0f172a;
+      border: 1px solid rgba(59, 130, 246, 0.2);
+      border-radius: 16px;
+      padding: 18px;
+      box-shadow: 0 12px 32px rgba(2, 6, 23, 0.5);
+    }
+
+    .issue-header {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+      padding-bottom: 12px;
+      margin-bottom: 12px;
+    }
+
+    .issue-title-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .issue-title { font-size: 18px; font-weight: 600; color: #f1f5f9; }
+    .issue-id { font-size: 14px; color: var(--mut); }
+
+    .issue-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      font-size: 13px;
+      color: var(--mut);
+    }
+
+    .issue-advice-label { font-weight: 600; margin-right: 6px; }
+
+    .issue-stacks {
+      margin-top: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.07);
+      border-radius: 12px;
+      padding: 12px;
+      background: #050910;
+    }
+
+    .issue-stacks summary {
+      cursor: pointer;
+      font-weight: 600;
+      color: var(--fg);
+      outline: none;
+    }
+
+    .issue-stack-list {
+      list-style: none;
+      padding: 0;
+      margin: 10px 0 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .issue-stack-item {
+      background: #0b1120;
+      border-radius: 10px;
+      padding: 10px 12px;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 12px;
+      align-items: flex-start;
+      border: 1px solid rgba(255, 255, 255, 0.04);
+    }
+
+    .issue-stack-hits {
+      font-size: 11px;
+      color: #60a5fa;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      background: rgba(59, 130, 246, 0.12);
+      border-radius: 999px;
+      padding: 4px 10px;
+      font-weight: 600;
+      line-height: 1;
+      white-space: nowrap;
+    }
+
+    .issue-stack-frames {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+      background: rgba(5, 9, 16, 0.8);
+    }
+
+    .issue-stack-frame {
+      font-size: 12px;
+      color: #cbd5f5;
+      border-radius: 8px;
+      padding: 1px 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .issue-stack-frame-code {
+      font-size: 12px;
+      background: none;
+      padding: 0;
+      border-radius: 0;
+      display: block;
+      max-width: 100%;
+      word-break: initial;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: #f8fafc;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
     #addFlamegraph + .flame-label::before { content: "🚫"; margin-right: 6px; }
     #addFlamegraph:checked + .flame-label::before { content: "🔥"; }
     #addDetector + .flame-label::before { content: "🚫"; margin-right: 6px; }
     #addDetector:checked + .flame-label::before { content: "🔍"; }
-
   </style>
 </head>
 <body>
@@ -77,7 +434,7 @@
     <section class="panel" aria-label="File upload">
       <h1>File Upload</h1>
       <p>Drag and drop files or select manually. Upload via <code>fetch</code>.</p>
-      <p><a href="/heapdump.html" style="color:#93c5fd;text-decoration:none;">Heap dump stats (JOL)</a></p>
+      <p><a href="/heapdump.html" class="link-muted">Heap dump stats (JOL)</a></p>
 
       <input id="fileInput" type="file" name="files" multiple hidden>
 
@@ -88,15 +445,13 @@
           <button type="button" id="send">Send files</button>
         </div>
       </div>
-      <label for="addFlamegraph"
-        style="display:flex;gap:8px;align-items:center;justify-content:flex-start;margin-top:10px;color:#cbd5e1;font-size:14px;cursor:pointer;">
+      <label for="addFlamegraph" class="option-toggle">
         <input id="addFlamegraph" type="checkbox" class="sr-only">
-        <span class="flame-label" style="font-weight:600;">Add flamegraphs</span>
+        <span class="flame-label">Add flamegraphs</span>
       </label>
-      <label for="addDetector"
-        style="display:flex;gap:8px;align-items:center;justify-content:flex-start;margin-top:10px;color:#cbd5e1;font-size:14px;cursor:pointer;">
+      <label for="addDetector" class="option-toggle">
         <input id="addDetector" type="checkbox" class="sr-only">
-        <span class="flame-label" style="font-weight:600;">Add detector</span>
+        <span class="flame-label">Add detector</span>
       </label>
 
       <ul id="list" aria-live="polite"></ul>
@@ -105,7 +460,7 @@
 
     <section class="panel" aria-label="Link history">
       <div class="history">
-        <div class="row" style="justify-content:space-between;margin:0 0 6px 0">
+        <div class="row history-header">
           <strong>History</strong>
           <button type="button" id="clear" class="ghost">Clear</button>
         </div>


### PR DESCRIPTION
### Motivation
- Reduce vertical spacing between entries in the History panel so the list appears more compact and readable.

### Description
- Adjusted `.history li` in `resources/public/index.html` by adding `padding: 0` and `line-height: 1.2` to decrease per-row height.

### Testing
- Served `resources/public` with `python -m http.server 8081` and ran a Playwright script to open `http://127.0.0.1:8081/index.html` and capture a full-page screenshot, which completed successfully and produced `artifacts/index-history-tight.png`.
