### PR TITLE
Support filesystem JFR paths in UI and API

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -127,6 +127,26 @@
 
     .flame-label { font-weight: 600; }
 
+    .path-input {
+      width: 100%;
+      margin-top: 12px;
+      min-height: 88px;
+      border-radius: 10px;
+      border: 1px solid #334155;
+      background: #0b1220;
+      color: var(--fg);
+      padding: 10px;
+      resize: vertical;
+      font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    .path-help {
+      display: block;
+      margin-top: 6px;
+      color: var(--mut);
+      font-size: 12px;
+    }
+
     .history {
       border: 2px dashed #334155;
       border-radius: 14px;
@@ -433,10 +453,13 @@
   <div class="grid">
     <section class="panel" aria-label="File upload">
       <h1>File Upload</h1>
-      <p>Drag and drop files or select manually. Upload via <code>fetch</code>.</p>
+      <p>Drag and drop files, select manually, or paste filesystem paths. Upload via <code>fetch</code>.</p>
       <p><a href="/heapdump.html" class="link-muted">Heap dump stats (JOL)</a></p>
 
       <input id="fileInput" type="file" name="files" multiple hidden>
+      <textarea id="filePaths" class="path-input" placeholder="/var/log/profile-1.jfr
+/var/log/profile-2.jfr" aria-label="JFR file paths"></textarea>
+      <small class="path-help">You can provide one filesystem path per line and/or upload files.</small>
 
       <div id="drop" class="drop" tabindex="0" role="button" aria-label="Drop area for files">
         Drag files here or click
@@ -499,6 +522,7 @@
   const clearBtn = document.getElementById('clear');
   const flameCheckbox = document.getElementById('addFlamegraph');
   const detectorCheckbox = document.getElementById('addDetector');
+  const filePathsInput = document.getElementById('filePaths');
   const STATS_TITLE_MAX = 400;
   const setStatus = (txt = '') => { status.textContent = txt; };
   const resetProgress = () => { prog.hidden = true; prog.value = 0; };
@@ -786,7 +810,8 @@
 
   // Send files via fetch (async)
   async function sendFiles(){
-    if(!fileInput.files.length){ alert('Please select files first.'); return; }
+    const rawPaths = filePathsInput.value.trim();
+    if(!fileInput.files.length && !rawPaths){ alert('Please select files or provide paths first.'); return; }
     const currentBatch = lastSelectedBatchId; // remember what exactly we send
     const addFlamegraph = flameCheckbox.checked;
     const addDetector = detectorCheckbox.checked;
@@ -799,6 +824,7 @@
       [...fileInput.files].forEach(f => fd.append('files', f, f.name));
       fd.append('addFlamegraph', addFlamegraph ? 'true' : 'false');
       fd.append('addDetector', addDetector ? 'true' : 'false');
+      if(rawPaths) fd.append('filePaths', rawPaths);
 
       const resp = await fetch(UPLOAD_URL, {method:'POST', body: fd});
       clearInterval(t); prog.value = 100;

--- a/src/clj/jfr/core.clj
+++ b/src/clj/jfr/core.clj
@@ -34,10 +34,17 @@
 (defroutes handlers
   (GET "/" [] index)
   (GET "/api/convertor/:uuid" [uuid] (get-artifact uuid "text/html"))
-  (POST "/api/convertor" req (let [[uuid stats add-flame? add-detector?] (service/generate-artifacts req)]
-                               {:status 200
-                                :headers {"Content-Type" "application/json"}
-                                :body (json/write-str {:uuid uuid :stats stats :flame add-flame? :detector add-detector?})}))
+  (POST "/api/convertor" req
+    (try
+      (let [[uuid stats add-flame? add-detector?] (service/generate-artifacts req)]
+        {:status 200
+         :headers {"Content-Type" "application/json"}
+         :body (json/write-str {:uuid uuid :stats stats :flame add-flame? :detector add-detector?})})
+      (catch clojure.lang.ExceptionInfo e
+        {:status 400
+         :headers {"Content-Type" "application/json"}
+         :body (json/write-str {:error (.getMessage e)
+                                :details (ex-data e)})})))
   (POST "/api/heapdump" req (let [response (heapdump/handle-heapdump-upload req)]
                              (try
                                {:status 200

--- a/src/clj/jfr/service.clj
+++ b/src/clj/jfr/service.clj
@@ -3,6 +3,7 @@
            (one.convert JfrToHeatmap JfrToFlame Arguments)
            (java.io ByteArrayOutputStream)
            (one.jfr JfrReader)
+           (java.nio.file Files Paths)
            (java.nio.charset StandardCharsets))
   (:require [clojure.java.io :as io]
             [clojure.data.json :as json]
@@ -11,7 +12,8 @@
             [jfr.utils :as utils]
             [jfr.environ :as env]
             [jfr.detector.detector :as detector]
-            [jfr.detector.worker :as detector-worker]))
+            [jfr.detector.worker :as detector-worker]
+            [clojure.string :as string]))
 
 (defn- get-temp-dir [] (env/temp-dir))
 
@@ -98,22 +100,55 @@
                (write-detector-result! uuid result)))))))
     (log/info (str "Scheduled detector job for " uuid " at " scheduled-at))))
 
+(defn- parse-filesystem-paths [raw-paths]
+  (->> (utils/normalize-vector raw-paths)
+       (mapcat #(string/split (str %) #"\r?\n"))
+       (map string/trim)
+       (remove string/blank?)
+       vec))
+
+(defn- ensure-readable-jfr! [path-str]
+  (let [path (Paths/get path-str (make-array String 0))]
+    (when-not (Files/exists path (make-array java.nio.file.LinkOption 0))
+      (throw (ex-info "Filesystem JFR file does not exist"
+                      {:path path-str
+                       :reason :file-not-found})))
+    (when-not (Files/isRegularFile path (make-array java.nio.file.LinkOption 0))
+      (throw (ex-info "Filesystem JFR path must point to a file"
+                      {:path path-str
+                       :reason :not-a-file})))
+    (when-not (Files/isReadable path)
+      (throw (ex-info "Filesystem JFR file is not readable"
+                      {:path path-str
+                       :reason :not-readable})))
+    path-str))
+
+(defn- collect-jfr-inputs [{:strs [files filePaths]}]
+  (let [uploaded-paths (->> (utils/normalize-vector files)
+                            (filter #(and (map? %) (contains? % :tempfile)))
+                            (mapv (comp str :tempfile)))
+        fs-paths (->> (parse-filesystem-paths filePaths)
+                      (mapv ensure-readable-jfr!))
+        all-inputs (into uploaded-paths fs-paths)]
+    (when (empty? all-inputs)
+      (throw (ex-info "At least one JFR file must be provided"
+                      {:reason :missing-inputs})))
+    all-inputs))
+
 (defn generate-artifacts [{:keys [params]}]
   (let [uuid (str (UUID/randomUUID))
         temp-dir (get-temp-dir)
         merged-path (str temp-dir "/" uuid ".jfr")
-        files (->> (get params "files")
-                   utils/normalize-vector
-                   (filterv #(and (map? %) (contains? % :tempfile))))
+        inputs (collect-jfr-inputs params)
         add-flame? (= "true" (get params "addFlamegraph"))
         add-detector? (= "true" (get params "addDetector"))]
     (io/make-parents merged-path)
     (log/info (str "UUID: " uuid " "
                    (if add-flame? "with flamegraph" "without flamegraph")
-                   "\n\t\tFiles to merge: " files))
+                   "\n\t\tFiles to merge: " inputs))
     (with-open [out (io/output-stream merged-path)]
-      (doseq [file files]
-        (with-open [in (io/input-stream (:tempfile file))]
+      (doseq [input inputs]
+        (with-open [in (io/input-stream input)]
           (io/copy in out))))
     (doseq [{:keys [suffix flag]} [{:suffix "" :flag nil}
                                    {:suffix "-cpu" :flag "--cpu"}

--- a/test/jfr/service_test.clj
+++ b/test/jfr/service_test.clj
@@ -13,3 +13,23 @@
 (deftest jfr-stats-missing-file
   (is (thrown? java.nio.file.NoSuchFileException
                (service/jfr-stats "missing.jfr"))))
+
+
+(deftest collect-jfr-inputs-supports-filesystem-paths
+  (let [tmp (java.io.File/createTempFile "service-test" ".jfr")
+        path (.getAbsolutePath tmp)]
+    (.deleteOnExit tmp)
+    (is (= [path]
+           (#'jfr.service/collect-jfr-inputs {"filePaths" path})))
+    (is (= [path path]
+           (#'jfr.service/collect-jfr-inputs {"filePaths" (str path "\n" path)})))))
+
+(deftest collect-jfr-inputs-requires-existing-readable-file
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"does not exist"
+                        (#'jfr.service/collect-jfr-inputs {"filePaths" "/tmp/definitely-missing-file.jfr"}))))
+
+(deftest collect-jfr-inputs-requires-at-least-one-input
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"At least one JFR file"
+                        (#'jfr.service/collect-jfr-inputs {}))))


### PR DESCRIPTION
### Motivation
- Allow users to reference JFR captures that already exist on the server filesystem instead of requiring a multipart upload, enabling faster workflows for large recordings.
- Validate filesystem inputs early to provide clear error payloads and avoid silent failures during the merge/convert pipeline.

### Description
- Added parsing and validation for newline-separated filesystem paths (`filePaths`) and a `collect-jfr-inputs` helper to merge uploaded files and filesystem paths into a single input list used by the converter pipeline (`src/clj/jfr/service.clj`).
- Implemented `ensure-readable-jfr!` checks that verify existence, regular-file status and readability and return clear `ExceptionInfo` on failure (`service.clj`).
- Made `generate-artifacts` consume the unified `inputs` list (uploads + filesystem paths) and stream-merge them as before (`service.clj`).
- Updated the convertor endpoint to return a `400` JSON error payload when an `ExceptionInfo` is raised during input validation (`src/clj/jfr/core.clj`).
- Updated the web UI to add a `textarea` for `filePaths`, client-side validation to allow files or paths (or both), and to send `filePaths` in the `FormData` payload (`resources/public/index.html`).
- Added unit tests for filesystem-path handling and missing-input validation (`test/jfr/service_test.clj`).

### Testing
- Ran environment preparation with `./prepare-env.sh`, which completed successfully with external package warnings unrelated to code changes.
- Ran the test suite with `clj -M:test`, which completed successfully: `Ran 17 tests containing 40 assertions. 0 failures, 0 errors`.
- Started the server and performed a smoke check by loading `/index.html` and capturing a screenshot to verify the new UI field rendered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69add46e98c88327b36814c9365a3137)