### PR TITLE
Persist converter history metadata in RocksDB

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,10 +19,11 @@
             :exec-fn jfr.core/-main
             :exec-args {:compile true}}
   :repl {:jvm-opts    ["-Xmx8g" "-Xms8g" "-XX:+UnlockDiagnosticVMOptions" "-XX:+DebugNonSafepoints" "-Djdk.attach.allowAttachSelf" "-XX:+EnableDynamicAgentLoading" "--enable-native-access=ALL-UNNAMED"]
-         :extra-paths ["src/repl"]
+         :extra-paths ["src/repl" "test"]
          :extra-deps {cider/cider-nrepl {:mvn/version "0.59.0"}
                       nrepl/nrepl       {:mvn/version "1.7.0"}
-                      com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.7.0"}}
+                      com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.7.0"}
+                      org.clojure/tools.namespace {:mvn/version "1.5.1"}}
          :main-opts  ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]" "-p" "5000" "-b" "0.0.0.0"]}
   :build {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.13"}}
           :paths ["src/build"]

--- a/resources/public/heapdump.html
+++ b/resources/public/heapdump.html
@@ -84,6 +84,23 @@
 
     a { color: #93c5fd; text-decoration: none; }
     a:hover { text-decoration: underline; }
+
+    .history {
+      margin-top: 16px;
+      border-top: 1px solid #223;
+      padding-top: 12px;
+      max-height: 260px;
+      overflow: auto;
+    }
+
+    .history-item {
+      padding: 8px 10px;
+      border: 1px solid #223;
+      border-radius: 8px;
+      margin-bottom: 8px;
+      background: #0b1325;
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
@@ -101,6 +118,10 @@
     <progress id="progress" max="100" value="0" hidden></progress>
     <div id="status" class="status"></div>
     <pre id="output" class="output" aria-live="polite"></pre>
+    <div class="history">
+      <h2>history-heapdump-stats</h2>
+      <div id="history" class="status">Loading…</div>
+    </div>
   </section>
 
 <script>
@@ -113,6 +134,7 @@
   const status = document.getElementById('status');
   const output = document.getElementById('output');
   const progress = document.getElementById('progress');
+  const history = document.getElementById('history');
 
   let selectedFile = null;
   let bytesSent = 0;
@@ -120,6 +142,37 @@
   const setStatus = (text) => { status.textContent = text; };
   const resetOutput = () => { output.textContent = ''; };
   const uploadUrl = () => `${location.origin}/api/heapdump`;
+  const historyUrl = () => `${location.origin}/api/history-heapdump-stats`;
+
+  const formatDate = (millis) => new Date(millis).toLocaleString();
+
+  const loadHistory = async () => {
+    try {
+      const response = await fetch(historyUrl());
+      if (!response.ok) {
+        history.textContent = 'Failed to load history.';
+        return;
+      }
+      const items = await response.json();
+      if (!items.length) {
+        history.textContent = 'No heapdump history yet.';
+        return;
+      }
+      history.innerHTML = '';
+      items.forEach((item) => {
+        const row = document.createElement('div');
+        row.className = 'history-item';
+        row.textContent = `${item.name} — ${formatDate(item.createdAt || item['created-at'])}`;
+        row.addEventListener('click', () => {
+          output.textContent = item.stats;
+          setStatus(`Loaded from history: ${item.name}`);
+        });
+        history.appendChild(row);
+      });
+    } catch (_err) {
+      history.textContent = 'Failed to load history.';
+    }
+  };
 
   pickBtn.addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', (event) => {
@@ -157,12 +210,14 @@
       }
       setStatus('Done.');
       output.textContent = await response.text();
+      await loadHistory();
     } catch (error) {
       setStatus(`Error: ${error.message || 'Upload failed'}`);
     }
   };
 
   sendBtn.addEventListener('click', sendHeapdump);
+  loadHistory();
 })();
 </script>
 </body>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -574,9 +574,10 @@
     }
   }
   async function clearDatabase(){
-    renderHistory();
     try{
-      await fetch(CLEAR_API, {method:'POST'});
+      fetch(CLEAR_API, {method:'POST'}).then((_)=>{
+        renderHistory();
+      });
     }catch(err){
       console.warn('Failed to clear server history:', err);
     }

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -485,6 +485,7 @@
   // 1) Settings. Set your real endpoint here:
   const UPLOAD_URL = '/api/convertor';
   const HISTORY_API = '/api/history';
+  const CLEAR_API = '/api/clear';
 
   // 3) DOM elements:
   const drop = document.getElementById('drop');
@@ -572,10 +573,10 @@
       return [];
     }
   }
-  async function clearHistory(){
+  async function clearDatabase(){
     renderHistory();
     try{
-      await fetch(HISTORY_API + '/clear', {method:'POST'});
+      await fetch(CLEAR_API, {method:'POST'});
     }catch(err){
       console.warn('Failed to clear server history:', err);
     }
@@ -784,7 +785,7 @@
   pick.addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', () => setFiles(fileInput.files));
   sendBtn.addEventListener('click', sendFiles);
-  clearBtn.addEventListener('click', clearHistory);
+  clearBtn.addEventListener('click', clearDatabase);
 
   // Initialization
   renderHistory();

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -462,7 +462,7 @@
       <div class="history">
         <div class="row history-header">
           <strong>History</strong>
-          <button type="button" id="clear" class="ghost">Clear</button>
+          <button type="button" id="clear" class="ghost">Clear DataBase</button>
         </div>
         <ol id="history"></ol>
       </div>
@@ -484,8 +484,6 @@
   'use strict';
   // 1) Settings. Set your real endpoint here:
   const UPLOAD_URL = '/api/convertor';
-  // 2) Keys in localStorage:
-  const LS_KEY = 'htmlLinksHistory';
   const HISTORY_API = '/api/history';
 
   // 3) DOM elements:
@@ -563,92 +561,23 @@
     return nameSpan;
   };
 
-  // === Link history on the right ===
-  function loadHistory(){
+    // === Link history on the right ===
+    async function loadHistory(){
     try{
-      const raw = JSON.parse(localStorage.getItem(LS_KEY) || '[]');
-      if(!Array.isArray(raw)) return [];
-      return raw.map(item => {
-        if(!item || typeof item !== 'object' || !item.uuid) return null;
-        return {
-          ...item,
-          name: typeof item.name === 'string' ? item.name : '',
-          flame: Boolean(item.flame)
-        };
-      }).filter(Boolean);
-    }catch{
+      const response = await fetch(HISTORY_API);
+      if(!response.ok) throw new Error('HTTP ' + response.status);
+      return response.json();
+    }catch(err){
+      console.warn('Failed to load history from server:', err);
       return [];
     }
   }
-  function saveHistory(arr){ localStorage.setItem(LS_KEY, JSON.stringify(arr)); }
-  function addToHistory(obj){
-    if(!obj || !obj.uuid) return;
-    const arr = loadHistory();
-    const idx = arr.findIndex(x => x.uuid === obj.uuid);
-    if(idx !== -1){
-      const existing = arr[idx];
-      const updated = {
-        ...existing,
-        ...obj,
-        name: existing.name || ''
-      };
-      arr.splice(idx, 1);
-      arr.unshift(updated);
-    } else {
-      const entry = {
-        ...obj,
-        name: typeof obj.name === 'string' ? obj.name : '',
-        flame: Boolean(obj.flame)
-      };
-      arr.unshift(entry);
-    }
-    saveHistory(arr);
-    renderHistory();
-  }
-  function normalizeConvertorPayload(raw){
-    const payload = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    if(!payload || typeof payload !== 'object') throw new Error('Payload must be an object or JSON string');
-    if(!payload.uuid) throw new Error('Payload must include a uuid field');
-    return {
-      uuid: String(payload.uuid),
-      stats: payload.stats,
-      flame: Boolean(payload.flame),
-      detector: Boolean(payload.detector),
-      name: typeof payload.name === 'string' ? payload.name : ''
-    };
-  }
-  function applyConvertorResponse(rawPayload, {statusMessage = 'Simulated response applied.'} = {}){
-    const normalized = normalizeConvertorPayload(rawPayload);
-    addToHistory(normalized);
-    setStatus(statusMessage);
-    resetProgress();
-    return normalized;
-  }
-  window.applyConvertorResponse = applyConvertorResponse;
   async function clearHistory(){
-    saveHistory([]);
     renderHistory();
     try{
       await fetch(HISTORY_API + '/clear', {method:'POST'});
     }catch(err){
       console.warn('Failed to clear server history:', err);
-    }
-  }
-  async function persistHistoryName(uuid, newName){
-    const arr = loadHistory();
-    const idx = arr.findIndex(item => item.uuid === uuid);
-    if(idx === -1) return;
-    arr[idx].name = newName;
-    saveHistory(arr);
-    renderHistory();
-    try{
-      await fetch(`${HISTORY_API}/${encodeURIComponent(uuid)}/name`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({name: newName})
-      });
-    }catch(err){
-      console.warn('Failed to persist name on server:', err);
     }
   }
   function placeCaretAtEnd(el){
@@ -688,31 +617,20 @@
       persistHistoryName(uuid, storedValue);
     }
   }
-  async function syncHistoryFromServer(){
-    try{
-      const response = await fetch(HISTORY_API);
-      if(!response.ok) throw new Error('HTTP ' + response.status);
-      const serverHistory = await response.json();
-      if(Array.isArray(serverHistory)){
-        saveHistory(serverHistory);
-        renderHistory();
-      }
-    }catch(err){
-      console.warn('Failed to load history from server:', err);
-    }
-  }
 
   function renderHistory(){
-    const arr = loadHistory();
     historyEl.innerHTML = '';
-    if(arr.length === 0){
+    const arr = loadHistory().then((history) => {
+      if(history.length === 0){
       const li = document.createElement('li');
       li.textContent = 'No links yet';
       historyEl.append(li);
       return;
     }
     const frag = document.createDocumentFragment();
-    arr.forEach(item => {
+    console.log(history);
+
+    history.forEach(item => {
       const li = document.createElement('li');
 
       const uuidSpan = document.createElement('span');
@@ -769,6 +687,7 @@
       frag.append(li);
     });
     historyEl.append(frag);
+    });
   }
 
   // === File handling on the left ===
@@ -836,11 +755,12 @@
       clearInterval(t); prog.value = 100;
       if(!resp.ok) throw new Error('HTTP '+resp.status);
 
-      const result = await resp.json().catch(()=>null);
-      if(!result || !result.uuid){
-        setStatus('Uploaded, but the server did not return a valid uuid.');
+      if(resp.status === 201){
+        renderHistory();
+        setStatus('Done');
+        resetProgress();
       } else {
-        applyConvertorResponse(result, {statusMessage: 'Done'});
+        setStatus('Something wrong!');
       }
 
       // Do not remove current items immediately — only after 10 seconds
@@ -868,7 +788,6 @@
 
   // Initialization
   renderHistory();
-  syncHistoryFromServer();
 })();
 </script>
 <script>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -582,6 +582,21 @@
       console.warn('Failed to clear server history:', err);
     }
   }
+
+  async function persistHistoryName(uuid, newName){
+    try{
+      await fetch(`${HISTORY_API}/${encodeURIComponent(uuid)}/name`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name: newName})
+      }).then((_)=>{
+        renderHistory();
+      });
+    }catch(err){
+      console.warn('Failed to persist name on server:', err);
+    }
+  }
+
   function placeCaretAtEnd(el){
     const range = document.createRange();
     range.selectNodeContents(el);

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -630,7 +630,6 @@
       return;
     }
     const frag = document.createDocumentFragment();
-    console.log(history);
 
     history.forEach(item => {
       const li = document.createElement('li');

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -486,6 +486,7 @@
   const UPLOAD_URL = '/api/convertor';
   // 2) Keys in localStorage:
   const LS_KEY = 'htmlLinksHistory';
+  const HISTORY_API = '/api/history';
 
   // 3) DOM elements:
   const drop = document.getElementById('drop');
@@ -624,14 +625,31 @@
     return normalized;
   }
   window.applyConvertorResponse = applyConvertorResponse;
-  function clearHistory(){ saveHistory([]); renderHistory(); }
-  function persistHistoryName(uuid, newName){
+  async function clearHistory(){
+    saveHistory([]);
+    renderHistory();
+    try{
+      await fetch(HISTORY_API + '/clear', {method:'POST'});
+    }catch(err){
+      console.warn('Failed to clear server history:', err);
+    }
+  }
+  async function persistHistoryName(uuid, newName){
     const arr = loadHistory();
     const idx = arr.findIndex(item => item.uuid === uuid);
     if(idx === -1) return;
     arr[idx].name = newName;
     saveHistory(arr);
     renderHistory();
+    try{
+      await fetch(`${HISTORY_API}/${encodeURIComponent(uuid)}/name`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name: newName})
+      });
+    }catch(err){
+      console.warn('Failed to persist name on server:', err);
+    }
   }
   function placeCaretAtEnd(el){
     const range = document.createRange();
@@ -670,6 +688,20 @@
       persistHistoryName(uuid, storedValue);
     }
   }
+  async function syncHistoryFromServer(){
+    try{
+      const response = await fetch(HISTORY_API);
+      if(!response.ok) throw new Error('HTTP ' + response.status);
+      const serverHistory = await response.json();
+      if(Array.isArray(serverHistory)){
+        saveHistory(serverHistory);
+        renderHistory();
+      }
+    }catch(err){
+      console.warn('Failed to load history from server:', err);
+    }
+  }
+
   function renderHistory(){
     const arr = loadHistory();
     historyEl.innerHTML = '';
@@ -836,6 +868,7 @@
 
   // Initialization
   renderHistory();
+  syncHistoryFromServer();
 })();
 </script>
 <script>

--- a/src/clj/jfr/core.clj
+++ b/src/clj/jfr/core.clj
@@ -31,6 +31,22 @@
       {:status 404
        :body "Artifact not found"})))
 
+
+(defn- parse-json-body [req]
+  (when-let [body (:body req)]
+    (json/read-str (slurp body) :key-fn keyword)))
+
+(defn- history-name-response [uuid req]
+  (let [{:keys [name]} (parse-json-body req)
+        updated (service/save-history-name! uuid (or name ""))]
+    (if updated
+      {:status 200
+       :headers {"Content-Type" "application/json"}
+       :body (json/write-str updated)}
+      {:status 404
+       :headers {"Content-Type" "application/json"}
+       :body (json/write-str {:error "History item not found"})})))
+
 (defroutes handlers
   (GET "/" [] index)
   (GET "/api/convertor/:uuid" [uuid] (get-artifact uuid "text/html"))
@@ -69,6 +85,14 @@
   (GET "/api/storage/keys" [] {:status 200
                                 :headers {"Content-Type" "application/json"}
                                 :body (json/write-str (storage/get-all-keys))})
+  (GET "/api/history" [] {:status 200
+                            :headers {"Content-Type" "application/json"}
+                            :body (json/write-str (service/load-history))})
+  (POST "/api/history/:uuid/name" [uuid :as req] (history-name-response uuid req))
+  (POST "/api/history/clear" [] (do (service/clear-history!)
+                                      {:status 200
+                                       :headers {"Content-Type" "application/json"}
+                                       :body (json/write-str {:ok true})}))
   (resources "/"))
 
 (defonce server (atom nil))

--- a/src/clj/jfr/core.clj
+++ b/src/clj/jfr/core.clj
@@ -31,6 +31,20 @@
       {:status 404
        :body "Artifact not found"})))
 
+(defn- parse-json-body [req]
+  (when-let [body (:body req)]
+    (json/read-str (slurp body) :key-fn keyword)))
+
+(defn- history-name-response [uuid req]
+  (let [{:keys [name]} (parse-json-body req)
+        updated (service/save-history-name! uuid (or name ""))]
+    (if updated
+      {:status 200
+       :headers {"Content-Type" "application/json"}
+       :body (json/write-str updated)}
+      {:status 404
+       :headers {"Content-Type" "application/json"}
+       :body (json/write-str {:error "History item not found"})})))
 
 (defroutes handlers
   (GET "/" [] index)
@@ -69,7 +83,8 @@
                                 :body (json/write-str (storage/get-all-keys))})
   (GET "/api/history" [] {:status 200
                             :headers {"Content-Type" "application/json"}
-                            :body (json/write-str (service/load-history))})
+                            :body (json/write-str (service/load-history))}) 
+  (POST "/api/history/:uuid/name" [uuid :as req] (history-name-response uuid req))
   (POST "/api/clear" [] (do (service/clear!) {:status 201}))
   (resources "/"))
 

--- a/src/clj/jfr/core.clj
+++ b/src/clj/jfr/core.clj
@@ -70,10 +70,7 @@
   (GET "/api/history" [] {:status 200
                             :headers {"Content-Type" "application/json"}
                             :body (json/write-str (service/load-history))})
-  (POST "/api/history/clear" [] (do (service/clear-history!)
-                                      {:status 200
-                                       :headers {"Content-Type" "application/json"}
-                                       :body (json/write-str {:ok true})}))
+  (POST "/api/clear" [] (do (service/clear!) {:status 201}))
   (resources "/"))
 
 (defonce server (atom nil))

--- a/src/clj/jfr/core.clj
+++ b/src/clj/jfr/core.clj
@@ -32,28 +32,10 @@
        :body "Artifact not found"})))
 
 
-(defn- parse-json-body [req]
-  (when-let [body (:body req)]
-    (json/read-str (slurp body) :key-fn keyword)))
-
-(defn- history-name-response [uuid req]
-  (let [{:keys [name]} (parse-json-body req)
-        updated (service/save-history-name! uuid (or name ""))]
-    (if updated
-      {:status 200
-       :headers {"Content-Type" "application/json"}
-       :body (json/write-str updated)}
-      {:status 404
-       :headers {"Content-Type" "application/json"}
-       :body (json/write-str {:error "History item not found"})})))
-
 (defroutes handlers
   (GET "/" [] index)
   (GET "/api/convertor/:uuid" [uuid] (get-artifact uuid "text/html"))
-  (POST "/api/convertor" req (let [[uuid stats add-flame? add-detector?] (service/generate-artifacts req)]
-                               {:status 200
-                                :headers {"Content-Type" "application/json"}
-                                :body (json/write-str {:uuid uuid :stats stats :flame add-flame? :detector add-detector?})}))
+  (POST "/api/convertor" req (let [body (service/generate-artifacts req)] {:status 201 :body body}))
   (POST "/api/heapdump" req (let [response (heapdump/handle-heapdump-upload req)]
                              (try
                                {:status 200
@@ -88,7 +70,6 @@
   (GET "/api/history" [] {:status 200
                             :headers {"Content-Type" "application/json"}
                             :body (json/write-str (service/load-history))})
-  (POST "/api/history/:uuid/name" [uuid :as req] (history-name-response uuid req))
   (POST "/api/history/clear" [] (do (service/clear-history!)
                                       {:status 200
                                        :headers {"Content-Type" "application/json"}
@@ -134,3 +115,4 @@
 
 ;; (-main)
 ;; (stop-server)
+

--- a/src/clj/jfr/core.clj
+++ b/src/clj/jfr/core.clj
@@ -84,6 +84,9 @@
   (GET "/api/history" [] {:status 200
                             :headers {"Content-Type" "application/json"}
                             :body (json/write-str (service/load-history))}) 
+  (GET "/api/history-heapdump-stats" [] {:status 200
+                                           :headers {"Content-Type" "application/json"}
+                                           :body (json/write-str (heapdump/load-heapdump-history))})
   (POST "/api/history/:uuid/name" [uuid :as req] (history-name-response uuid req))
   (POST "/api/clear" [] (do (service/clear!) {:status 201}))
   (resources "/"))
@@ -127,4 +130,3 @@
 
 ;; (-main)
 ;; (stop-server)
-

--- a/src/clj/jfr/heapdump.clj
+++ b/src/clj/jfr/heapdump.clj
@@ -1,13 +1,38 @@
 (ns jfr.heapdump
   (:require
    [clojure.java.io :as io]
-   [jfr.environ :as env])
+   [clojure.data.json :as json]
+   [jfr.environ :as env]
+   [jfr.storage :as storage])
   (:import
    (java.util UUID)
    (java.io File PrintWriter StringWriter)
    (org.openjdk.jol.datamodel ModelVM)
    (org.openjdk.jol.heap HeapDumpReader)
-   (org.openjdk.jol.layouters HotSpotLayouter)))
+   (org.openjdk.jol.layouters HotSpotLayouter)
+   (java.nio.charset StandardCharsets)))
+
+(def ^:private heapdump-history-prefix "meta-heapdump-history/")
+
+(defn- heapdump-history-key [name created-at]
+  (str heapdump-history-prefix created-at "|" name))
+
+(defn load-heapdump-history []
+  (->> (storage/get-all-keys heapdump-history-prefix)
+       (keep (fn [key]
+               (when-let [bytes (storage/load-bytes key)]
+                 (json/read-str (String. bytes StandardCharsets/UTF_8) :key-fn keyword))))
+       (sort-by :created-at >)
+       vec))
+
+(defn- save-heapdump-history! [name stats]
+  (let [created-at (System/currentTimeMillis)
+        item {:name name
+              :created-at created-at
+              :stats stats}
+        payload (.getBytes (json/write-str item) StandardCharsets/UTF_8)]
+    (storage/save-bytes (heapdump-history-key name created-at) payload)
+    item))
 
 (def ^:private column-order [:instances :size :sum-size])
 
@@ -106,9 +131,10 @@
           (with-open [in (io/input-stream tempfile)
                       out (io/output-stream path)]
             (io/copy in out))
-          (heapdump-stats-text path)
+          (let [stats-text (heapdump-stats-text path)]
+            (save-heapdump-history! filename stats-text)
+            stats-text)
           (finally
             (when path
               (.delete (File. path))))))
       (throw (IllegalArgumentException. "Missing heapdump file")))))
-

--- a/src/clj/jfr/service.clj
+++ b/src/clj/jfr/service.clj
@@ -7,6 +7,7 @@
   (:require [clojure.java.io :as io]
             [clojure.data.json :as json]
             [clojure.tools.logging :as log]
+            [clojure.string :as string]
             [jfr.storage :as storage]
             [jfr.utils :as utils]
             [jfr.environ :as env]
@@ -53,6 +54,47 @@
 
 (defn- detector-key [uuid]
   (str uuid "-detector"))
+
+(def ^:private history-prefix "meta-history/")
+
+(defn- history-key [uuid]
+  (str history-prefix uuid))
+
+(defn- normalize-history-item [item]
+  {:uuid (str (:uuid item))
+   :stats (:stats item)
+   :flame (boolean (:flame item))
+   :detector (boolean (:detector item))
+   :name (if (string? (:name item)) (:name item) "")
+   :created-at (or (:created-at item) (System/currentTimeMillis))})
+
+(defn save-history-item!
+  [item]
+  (let [{:keys [uuid] :as normalized} (normalize-history-item item)
+        bytes (.getBytes (json/write-str normalized) StandardCharsets/UTF_8)]
+    (storage/save-bytes (history-key uuid) bytes)
+    normalized))
+
+(defn load-history
+  []
+  (->> (storage/get-all-keys)
+       (filter #(string/starts-with? % history-prefix))
+       (keep (fn [key]
+               (when-let [bytes (storage/load-bytes key)]
+                 (json/read-str (String. bytes StandardCharsets/UTF_8) :key-fn keyword))))
+       (sort-by :created-at >)
+       vec))
+
+(defn save-history-name!
+  [uuid new-name]
+  (when-let [existing (first (filter #(= uuid (:uuid %)) (load-history)))]
+    (save-history-item! (assoc existing :name (or new-name "")))))
+
+(defn clear-history!
+  []
+  (doseq [key (storage/get-all-keys)
+          :when (string/starts-with? key history-prefix)]
+    (storage/delete key)))
 
 (defn- write-detector-result! [uuid data]
   (let [json-str (json/write-str data)
@@ -124,4 +166,9 @@
         (->> (convert-flamegraph merged-path flag)
              (storage/save-bytes (str uuid "-flame" suffix)))))
     (when add-detector? (schedule-detector! uuid merged-path))
-    [uuid (jfr-stats merged-path) add-flame? add-detector?]))
+    (let [stats (jfr-stats merged-path)]
+      (save-history-item! {:uuid uuid
+                           :stats stats
+                           :flame add-flame?
+                           :detector add-detector?})
+      [uuid stats add-flame? add-detector?])))

--- a/src/clj/jfr/service.clj
+++ b/src/clj/jfr/service.clj
@@ -77,8 +77,7 @@
 
 (defn load-history
   []
-  (->> (storage/get-all-keys)
-       (filter #(string/starts-with? % history-prefix))
+  (->> (storage/get-all-keys history-prefix)
        (keep (fn [key]
                (when-let [bytes (storage/load-bytes key)]
                  (json/read-str (String. bytes StandardCharsets/UTF_8) :key-fn keyword))))

--- a/src/clj/jfr/service.clj
+++ b/src/clj/jfr/service.clj
@@ -89,6 +89,12 @@
   (doseq [key (storage/get-all-keys)]
     (storage/delete key)))
 
+(defn save-history-name!
+  [uuid new-name]
+  (when-let [bytes (storage/load-bytes (str history-prefix uuid))]
+    (let [existing (json/read-str (String. bytes StandardCharsets/UTF_8) :key-fn keyword)]
+      (save-history-item! (assoc existing :name (or new-name ""))))))
+
 (defn- write-detector-result! [uuid data]
   (let [json-str (json/write-str data)
         bytes (.getBytes json-str StandardCharsets/UTF_8)]

--- a/src/clj/jfr/service.clj
+++ b/src/clj/jfr/service.clj
@@ -85,10 +85,9 @@
        (sort-by :created-at >)
        vec))
 
-(defn clear-history!
+(defn clear!
   []
-  (doseq [key (storage/get-all-keys)
-          :when (string/starts-with? key history-prefix)]
+  (doseq [key (storage/get-all-keys)]
     (storage/delete key)))
 
 (defn- write-detector-result! [uuid data]

--- a/src/clj/jfr/service.clj
+++ b/src/clj/jfr/service.clj
@@ -85,11 +85,6 @@
        (sort-by :created-at >)
        vec))
 
-(defn save-history-name!
-  [uuid new-name]
-  (when-let [existing (first (filter #(= uuid (:uuid %)) (load-history)))]
-    (save-history-item! (assoc existing :name (or new-name "")))))
-
 (defn clear-history!
   []
   (doseq [key (storage/get-all-keys)
@@ -171,4 +166,4 @@
                            :stats stats
                            :flame add-flame?
                            :detector add-detector?})
-      [uuid stats add-flame? add-detector?])))
+      uuid)))

--- a/src/clj/jfr/storage.clj
+++ b/src/clj/jfr/storage.clj
@@ -1,5 +1,6 @@
 (ns jfr.storage
-  (:import (org.rocksdb RocksDB Options CompressionType))
+  (:import (org.rocksdb RocksDB Options CompressionType)
+           (java.nio.charset StandardCharsets))
   (:require [jfr.environ :as env]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]))
@@ -57,19 +58,42 @@
                  "rocksdb.size-all-mem-tables"]] 
            (into {} (map (fn [p] [p (.getProperty db p)]) props)))))
 
-(defn get-all-keys []
-  (when-let [db @db-atom]
-    (let [it (.newIterator db)]
-      (try
-        (.seekToFirst it)
-        (loop [keys []]
-          (if (.isValid it)
-            (let [key (String. (.key it))]
-              (.next it)
-              (recur (conj keys key)))
-            keys))
-        (finally
-          (.close it))))))
+(defn starts-with-bytes? [^bytes value ^bytes prefix]
+  (and (<= (alength prefix) (alength value))
+       (loop [i 0]
+         (cond
+           (= i (alength prefix)) true
+           (not= (aget value i) (aget prefix i)) false
+           :else (recur (inc i))))))
+
+(defn get-all-keys
+  ([]
+   (get-all-keys nil))
+
+  ([prefix]
+   (when-let [db @db-atom]
+     (let [it (.newIterator db)
+           prefix-bytes (when prefix
+                          (.getBytes ^String prefix StandardCharsets/UTF_8))]
+       (try
+         (if prefix-bytes
+           (.seek it prefix-bytes)
+           (.seekToFirst it))
+
+         (loop [keys []]
+           (if (.isValid it)
+             (let [key-bytes (.key it)]
+               (if (or (nil? prefix-bytes)
+                       (starts-with-bytes? key-bytes prefix-bytes))
+                 (let [key (String. key-bytes StandardCharsets/UTF_8)]
+                   (.next it)
+                   (recur (conj keys key)))
+
+                 keys))
+             keys))
+
+         (finally
+           (.close it)))))))
 
 (defn init []
   (open-db))

--- a/src/repl/repl.clj
+++ b/src/repl/repl.clj
@@ -5,7 +5,10 @@
    [jfr.detector.detector :as detector]
    [jfr.detector.report :as report]
    [hiccup2.core :as h]
-   [clojure.tools.logging :as log])
+   [clojure.tools.logging :as log] 
+   [clojure.tools.namespace.find :as ns-find]
+   [clojure.java.io :as io]
+   [clojure.test :as t])
   (:import [java.lang NullPointerException]))
 
 
@@ -74,3 +77,12 @@ report
 count
 
 (str (count (seq ["123"])))
+
+
+;;;;;; TESTS
+(let [dirs [(io/file "test")]
+      nss (ns-find/find-namespaces-in-dir (first dirs))]
+  (log/infof "Running tests in namespaces: %s" (vec nss))
+  (apply require nss)
+  (let [{:keys [fail error]} (apply t/run-tests nss)]
+    (println (if (pos? (+ (or fail 0) (or error 0))) 1 0))))

--- a/test/jfr/core_test.clj
+++ b/test/jfr/core_test.clj
@@ -49,7 +49,6 @@
 
 (deftest history-endpoints
   (with-redefs [jfr.service/load-history (fn [] [{:uuid "abc" :name "demo"}])
-                jfr.service/save-history-name! (fn [uuid name] {:uuid uuid :name name})
                 jfr.service/clear-history! (fn [] nil)]
     (let [get-response (core/app {:request-method :get
                                   :uri "/api/history"})

--- a/test/jfr/core_test.clj
+++ b/test/jfr/core_test.clj
@@ -45,3 +45,19 @@
           (core/stop-server)
           (is (nil? @core/server))
           (reset! core/server original-server))))))
+
+
+(deftest history-endpoints
+  (with-redefs [jfr.service/load-history (fn [] [{:uuid "abc" :name "demo"}])
+                jfr.service/save-history-name! (fn [uuid name] {:uuid uuid :name name})
+                jfr.service/clear-history! (fn [] nil)]
+    (let [get-response (core/app {:request-method :get
+                                  :uri "/api/history"})
+          post-response (core/app {:request-method :post
+                                   :uri "/api/history/abc/name"
+                                   :body (java.io.ByteArrayInputStream. (.getBytes "{\"name\":\"new\"}"))})
+          clear-response (core/app {:request-method :post
+                                    :uri "/api/history/clear"})]
+      (is (= 200 (:status get-response)))
+      (is (= 200 (:status post-response)))
+      (is (= 200 (:status clear-response))))))

--- a/test/jfr/core_test.clj
+++ b/test/jfr/core_test.clj
@@ -48,15 +48,10 @@
 
 
 (deftest history-endpoints
-  (with-redefs [jfr.service/load-history (fn [] [{:uuid "abc" :name "demo"}])
-                jfr.service/clear-history! (fn [] nil)]
+  (with-redefs [jfr.service/load-history (fn [] [{:uuid "abc" :name "demo"}])]
     (let [get-response (core/app {:request-method :get
                                   :uri "/api/history"})
-          post-response (core/app {:request-method :post
-                                   :uri "/api/history/abc/name"
-                                   :body (java.io.ByteArrayInputStream. (.getBytes "{\"name\":\"new\"}"))})
           clear-response (core/app {:request-method :post
-                                    :uri "/api/history/clear"})]
+                                    :uri "/api/clear"})]
       (is (= 200 (:status get-response)))
-      (is (= 200 (:status post-response)))
-      (is (= 200 (:status clear-response))))))
+      (is (= 201 (:status clear-response))))))

--- a/test/jfr/core_test.clj
+++ b/test/jfr/core_test.clj
@@ -55,3 +55,10 @@
                                     :uri "/api/clear"})]
       (is (= 200 (:status get-response)))
       (is (= 201 (:status clear-response))))))
+
+(deftest heapdump-history-endpoint
+  (with-redefs [jfr.heapdump/load-heapdump-history (fn [] [{:name "heap.hprof" :created-at 1700000000000 :stats "ok"}])]
+    (let [response (core/app {:request-method :get
+                              :uri "/api/history-heapdump-stats"})]
+      (is (= 200 (:status response)))
+      (is (.contains (str (:body response)) "heap.hprof")))))

--- a/test/jfr/heapdump_test.clj
+++ b/test/jfr/heapdump_test.clj
@@ -1,11 +1,14 @@
 (ns jfr.heapdump-test
   (:require
+   [clojure.data.json :as json]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is]]
-   [jfr.heapdump :as heapdump])
+   [jfr.heapdump :as heapdump]
+   [jfr.storage :as storage])
   (:import
    (com.sun.management HotSpotDiagnosticMXBean)
    (java.lang.management ManagementFactory)
+   (java.nio.charset StandardCharsets)
    (java.nio.file Files)))
 
 (defn- ^HotSpotDiagnosticMXBean hotspot-diagnostic []
@@ -29,3 +32,23 @@
       (finally
         (io/delete-file path true)
         (io/delete-file (.toFile temp-dir) true)))))
+
+(deftest heapdump-history-roundtrip
+  (let [db (atom {})]
+    (with-redefs [storage/get-all-keys (fn
+                                         ([] (storage/get-all-keys nil))
+                                         ([prefix]
+                                          (filter #(clojure.string/starts-with? % prefix)
+                                                  (keys @db))))
+                  storage/load-bytes (fn [k] (get @db k))
+                  storage/save-bytes (fn [k v] (swap! db assoc k v))]
+      (let [entry-1 {:name "a.hprof" :created-at 1700000000000 :stats "stats-a"}
+            entry-2 {:name "b.hprof" :created-at 1700000001000 :stats "stats-b"}
+            bytes-1 (.getBytes (json/write-str entry-1) StandardCharsets/UTF_8)
+            bytes-2 (.getBytes (json/write-str entry-2) StandardCharsets/UTF_8)]
+        (storage/save-bytes "meta-heapdump-history/1700000000000|a.hprof" bytes-1)
+        (storage/save-bytes "meta-heapdump-history/1700000001000|b.hprof" bytes-2)
+        (let [history (heapdump/load-heapdump-history)]
+          (is (= 2 (count history)))
+          (is (= "b.hprof" (:name (first history))))
+          (is (= "stats-a" (:stats (second history)))))))))

--- a/test/jfr/service_test.clj
+++ b/test/jfr/service_test.clj
@@ -27,8 +27,5 @@
       (let [history (service/load-history)]
         (is (= 2 (count history)))
         (is (= #{"u-1" "u-2"} (set (map :uuid history)))))
-
-      (is (= "renamed" (:name (first (filter #(= "u-2" (:uuid %)) (service/load-history))))))
-
       (service/clear!)
       (is (empty? (service/load-history))))))

--- a/test/jfr/service_test.clj
+++ b/test/jfr/service_test.clj
@@ -30,5 +30,5 @@
 
       (is (= "renamed" (:name (first (filter #(= "u-2" (:uuid %)) (service/load-history))))))
 
-      (service/clear-history!)
+      (service/clear!)
       (is (empty? (service/load-history))))))

--- a/test/jfr/service_test.clj
+++ b/test/jfr/service_test.clj
@@ -13,3 +13,22 @@
 (deftest jfr-stats-missing-file
   (is (thrown? java.nio.file.NoSuchFileException
                (service/jfr-stats "missing.jfr"))))
+
+(deftest history-metadata-roundtrip
+  (let [db (atom {})]
+    (with-redefs [jfr.storage/get-all-keys (fn [] (keys @db))
+                  jfr.storage/load-bytes (fn [k] (get @db k))
+                  jfr.storage/save-bytes (fn [k v] (swap! db assoc k v))
+                  jfr.storage/delete (fn [k] (swap! db dissoc k))]
+      (service/save-history-item! {:uuid "u-1" :stats {:event-count 1} :flame true :detector false})
+      (service/save-history-item! {:uuid "u-2" :stats {:event-count 2} :flame false :detector true :name "old"})
+
+      (let [history (service/load-history)]
+        (is (= 2 (count history)))
+        (is (= #{"u-1" "u-2"} (set (map :uuid history)))))
+
+      (service/save-history-name! "u-2" "renamed")
+      (is (= "renamed" (:name (first (filter #(= "u-2" (:uuid %)) (service/load-history))))))
+
+      (service/clear-history!)
+      (is (empty? (service/load-history))))))

--- a/test/jfr/service_test.clj
+++ b/test/jfr/service_test.clj
@@ -18,7 +18,7 @@
 (deftest history-metadata-roundtrip
   (let [db (atom {})]
     (with-redefs [storage/get-all-keys (fn
-                                         ([] (storage/get-all-keys nil)) 
+                                         ([] (storage/get-all-keys nil))
                                          ([_] (keys @db)))
                   storage/load-bytes (fn [k] (get @db k))
                   storage/save-bytes (fn [k v] (swap! db assoc k v))
@@ -29,5 +29,12 @@
       (let [history (service/load-history)]
         (is (= 2 (count history)))
         (is (= #{"u-1" "u-2"} (set (map :uuid history)))))
+
+      (service/save-history-name! "u-1" "changed")
+
+      (let [history (service/load-history)
+            u2 (first (filter #(= (:uuid %) "u-1") history))]
+        (is (= "changed" (:name u2))))
+
       (service/clear!)
       (is (empty? (service/load-history))))))

--- a/test/jfr/service_test.clj
+++ b/test/jfr/service_test.clj
@@ -1,6 +1,7 @@
 (ns jfr.service-test
   (:require [clojure.test :refer :all]
-            [jfr.service :as service]))
+            [jfr.service :as service]
+            [jfr.storage :as storage]))
 
 (deftest convert-heatmap-missing-file
   (is (thrown? java.nio.file.NoSuchFileException
@@ -16,10 +17,10 @@
 
 (deftest history-metadata-roundtrip
   (let [db (atom {})]
-    (with-redefs [jfr.storage/get-all-keys (fn [] (keys @db))
-                  jfr.storage/load-bytes (fn [k] (get @db k))
-                  jfr.storage/save-bytes (fn [k v] (swap! db assoc k v))
-                  jfr.storage/delete (fn [k] (swap! db dissoc k))]
+    (with-redefs [storage/get-all-keys (fn [] (keys @db))
+                  storage/load-bytes (fn [k] (get @db k))
+                  storage/save-bytes (fn [k v] (swap! db assoc k v))
+                  storage/delete (fn [k] (swap! db dissoc k))]
       (service/save-history-item! {:uuid "u-1" :stats {:event-count 1} :flame true :detector false})
       (service/save-history-item! {:uuid "u-2" :stats {:event-count 2} :flame false :detector true :name "old"})
 
@@ -27,7 +28,6 @@
         (is (= 2 (count history)))
         (is (= #{"u-1" "u-2"} (set (map :uuid history)))))
 
-      (service/save-history-name! "u-2" "renamed")
       (is (= "renamed" (:name (first (filter #(= "u-2" (:uuid %)) (service/load-history))))))
 
       (service/clear-history!)

--- a/test/jfr/service_test.clj
+++ b/test/jfr/service_test.clj
@@ -17,7 +17,9 @@
 
 (deftest history-metadata-roundtrip
   (let [db (atom {})]
-    (with-redefs [storage/get-all-keys (fn [] (keys @db))
+    (with-redefs [storage/get-all-keys (fn
+                                         ([] (storage/get-all-keys nil)) 
+                                         ([_] (keys @db)))
                   storage/load-bytes (fn [k] (get @db k))
                   storage/save-bytes (fn [k v] (swap! db assoc k v))
                   storage/delete (fn [k] (swap! db dissoc k))]


### PR DESCRIPTION
### Motivation
- Keep converter history durable on the server so UI history is not only stored in browser `localStorage` but also persisted with metadata for recovery and cross-client use.
- Allow the UI to sync, rename and clear history items from the backend so metadata (uuid, stats, flame/detector flags, editable name, timestamp) is authoritative and queryable.

### Description
- Added server-side history persistence helpers in `jfr.service`: `save-history-item!`, `load-history`, `save-history-name!`, and `clear-history!` storing entries under the `meta-history/` prefix in RocksDB and normalizing items with `created-at` timestamps.
- Persist converter history when artifacts are generated by updating `generate-artifacts` to compute `stats` once and call `save-history-item!` before returning the response.
- Exposed HTTP endpoints in `jfr.core`: `GET /api/history`, `POST /api/history/:uuid/name`, and `POST /api/history/clear` and added a small JSON body parser/handler to support name updates and clearing.
- Updated frontend `resources/public/index.html` to sync initial history from `GET /api/history`, to POST name updates to `/api/history/:uuid/name`, and to call `/api/history/clear` when clearing local history; localStorage remains as the UI cache.
- Added tests: a unit test for history metadata roundtrip in `test/jfr/service_test.clj` and HTTP endpoint tests in `test/jfr/core_test.clj`.

### Testing
- Ran the full test suite with `clj -M:test`, which executed the tests and completed successfully (16 tests, 43 assertions, 0 failures).
- The new service-level history tests and core endpoint tests were included and passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69add4aebc8c8327b8849d41a4373bdf)