### PR TITLE
chore(ci): bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: /tmp/.buildx-cache
           key: buildx-cache-${{ hashFiles('Dockerfile') }}
@@ -28,7 +28,7 @@ jobs:
           mkdir -p ~/.m2 && tree $PWD/
 
       - name: Cache Clojure Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.m2
           key: clojure-m2-cache-${{ hashFiles('deps.edn') }}


### PR DESCRIPTION
### Motivation
- Update CI workflow action references to recent releases to incorporate upstream fixes and improvements.

### Description
- Bumped action versions in ` .github/workflows/ci.yml`: `actions/checkout` → `v6.0.2`, `docker/setup-buildx-action` → `v4.0.0`, and both `actions/cache` steps → `v5.0.5`.

### Testing
- Verified latest release tags via the GitHub API using `curl` + `jq`, confirmed the workflow changes with `git diff -- .github/workflows/ci.yml`, and checked the working tree with `git status --short`, all checks passed.

------