### PR TITLE
Switch :outdated alias to com.github.liquidz/antq

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -31,5 +31,5 @@
          :jvm-opts ["--enable-native-access=ALL-UNNAMED"]
          :extra-deps {org.clojure/tools.namespace {:mvn/version "1.5.0"}}
          :main-opts ["-m" "test-runner"]}
-  :outdated {:replace-deps {olical/depot {:mvn/version "2.4.1"}}
-              :main-opts ["-m" "depot.outdated.main"]}}}
+  :outdated {:replace-deps {com.github.liquidz/antq {:mvn/version "2.11.1272"}}
+             :main-opts ["-m" "antq.core"]}}}


### PR DESCRIPTION
### Motivation
- Replace the `olical/depot` tool used by the `:outdated` alias with `com.github.liquidz/antq` to use the maintained dependency-check tool and its entrypoint.

### Description
- Modified `deps.edn` to set the `:outdated` alias to `:replace-deps {com.github.liquidz/antq {:mvn/version "2.11.1272"}}` and updated `:main-opts` to `["-m" "antq.core"]`.

### Testing
- Executed `./prepare-env.sh` and ran the test suite with `clj -M:test`, which completed successfully (14 tests, 36 assertions, 0 failures).

------