### PR TITLE
Persist heapdump-stats in RocksDB and add UI history list

### DIFF
--- a/resources/public/heapdump.html
+++ b/resources/public/heapdump.html
@@ -84,6 +84,23 @@
 
     a { color: #93c5fd; text-decoration: none; }
     a:hover { text-decoration: underline; }
+
+    .history {
+      margin-top: 16px;
+      border-top: 1px solid #223;
+      padding-top: 12px;
+      max-height: 260px;
+      overflow: auto;
+    }
+
+    .history-item {
+      padding: 8px 10px;
+      border: 1px solid #223;
+      border-radius: 8px;
+      margin-bottom: 8px;
+      background: #0b1325;
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
@@ -101,6 +118,10 @@
     <progress id="progress" max="100" value="0" hidden></progress>
     <div id="status" class="status"></div>
     <pre id="output" class="output" aria-live="polite"></pre>
+    <div class="history">
+      <h2>history-heapdump-stats</h2>
+      <div id="history" class="status">Loading…</div>
+    </div>
   </section>
 
 <script>
@@ -113,6 +134,7 @@
   const status = document.getElementById('status');
   const output = document.getElementById('output');
   const progress = document.getElementById('progress');
+  const history = document.getElementById('history');
 
   let selectedFile = null;
   let bytesSent = 0;
@@ -120,6 +142,37 @@
   const setStatus = (text) => { status.textContent = text; };
   const resetOutput = () => { output.textContent = ''; };
   const uploadUrl = () => `${location.origin}/api/heapdump`;
+  const historyUrl = () => `${location.origin}/api/history-heapdump-stats`;
+
+  const formatDate = (millis) => new Date(millis).toLocaleString();
+
+  const loadHistory = async () => {
+    try {
+      const response = await fetch(historyUrl());
+      if (!response.ok) {
+        history.textContent = 'Failed to load history.';
+        return;
+      }
+      const items = await response.json();
+      if (!items.length) {
+        history.textContent = 'No heapdump history yet.';
+        return;
+      }
+      history.innerHTML = '';
+      items.forEach((item) => {
+        const row = document.createElement('div');
+        row.className = 'history-item';
+        row.textContent = `${item.name} — ${formatDate(item.createdAt || item['created-at'])}`;
+        row.addEventListener('click', () => {
+          output.textContent = item.stats;
+          setStatus(`Loaded from history: ${item.name}`);
+        });
+        history.appendChild(row);
+      });
+    } catch (_err) {
+      history.textContent = 'Failed to load history.';
+    }
+  };
 
   pickBtn.addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', (event) => {
@@ -157,12 +210,14 @@
       }
       setStatus('Done.');
       output.textContent = await response.text();
+      await loadHistory();
     } catch (error) {
       setStatus(`Error: ${error.message || 'Upload failed'}`);
     }
   };
 
   sendBtn.addEventListener('click', sendHeapdump);
+  loadHistory();
 })();
 </script>
 </body>

--- a/src/clj/jfr/core.clj
+++ b/src/clj/jfr/core.clj
@@ -84,6 +84,9 @@
   (GET "/api/history" [] {:status 200
                             :headers {"Content-Type" "application/json"}
                             :body (json/write-str (service/load-history))}) 
+  (GET "/api/history-heapdump-stats" [] {:status 200
+                                           :headers {"Content-Type" "application/json"}
+                                           :body (json/write-str (heapdump/load-heapdump-history))})
   (POST "/api/history/:uuid/name" [uuid :as req] (history-name-response uuid req))
   (POST "/api/clear" [] (do (service/clear!) {:status 201}))
   (resources "/"))
@@ -127,4 +130,3 @@
 
 ;; (-main)
 ;; (stop-server)
-

--- a/src/clj/jfr/heapdump.clj
+++ b/src/clj/jfr/heapdump.clj
@@ -1,13 +1,38 @@
 (ns jfr.heapdump
   (:require
    [clojure.java.io :as io]
-   [jfr.environ :as env])
+   [clojure.data.json :as json]
+   [jfr.environ :as env]
+   [jfr.storage :as storage])
   (:import
    (java.util UUID)
    (java.io File PrintWriter StringWriter)
    (org.openjdk.jol.datamodel ModelVM)
    (org.openjdk.jol.heap HeapDumpReader)
-   (org.openjdk.jol.layouters HotSpotLayouter)))
+   (org.openjdk.jol.layouters HotSpotLayouter)
+   (java.nio.charset StandardCharsets)))
+
+(def ^:private heapdump-history-prefix "meta-heapdump-history/")
+
+(defn- heapdump-history-key [name created-at]
+  (str heapdump-history-prefix created-at "|" name))
+
+(defn load-heapdump-history []
+  (->> (storage/get-all-keys heapdump-history-prefix)
+       (keep (fn [key]
+               (when-let [bytes (storage/load-bytes key)]
+                 (json/read-str (String. bytes StandardCharsets/UTF_8) :key-fn keyword))))
+       (sort-by :created-at >)
+       vec))
+
+(defn- save-heapdump-history! [name stats]
+  (let [created-at (System/currentTimeMillis)
+        item {:name name
+              :created-at created-at
+              :stats stats}
+        payload (.getBytes (json/write-str item) StandardCharsets/UTF_8)]
+    (storage/save-bytes (heapdump-history-key name created-at) payload)
+    item))
 
 (def ^:private column-order [:instances :size :sum-size])
 
@@ -106,9 +131,10 @@
           (with-open [in (io/input-stream tempfile)
                       out (io/output-stream path)]
             (io/copy in out))
-          (heapdump-stats-text path)
+          (let [stats-text (heapdump-stats-text path)]
+            (save-heapdump-history! filename stats-text)
+            stats-text)
           (finally
             (when path
               (.delete (File. path))))))
       (throw (IllegalArgumentException. "Missing heapdump file")))))
-

--- a/test/jfr/core_test.clj
+++ b/test/jfr/core_test.clj
@@ -55,3 +55,10 @@
                                     :uri "/api/clear"})]
       (is (= 200 (:status get-response)))
       (is (= 201 (:status clear-response))))))
+
+(deftest heapdump-history-endpoint
+  (with-redefs [jfr.heapdump/load-heapdump-history (fn [] [{:name "heap.hprof" :created-at 1700000000000 :stats "ok"}])]
+    (let [response (core/app {:request-method :get
+                              :uri "/api/history-heapdump-stats"})]
+      (is (= 200 (:status response)))
+      (is (.contains (str (:body response)) "heap.hprof")))))

--- a/test/jfr/heapdump_test.clj
+++ b/test/jfr/heapdump_test.clj
@@ -1,11 +1,14 @@
 (ns jfr.heapdump-test
   (:require
+   [clojure.data.json :as json]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is]]
-   [jfr.heapdump :as heapdump])
+   [jfr.heapdump :as heapdump]
+   [jfr.storage :as storage])
   (:import
    (com.sun.management HotSpotDiagnosticMXBean)
    (java.lang.management ManagementFactory)
+   (java.nio.charset StandardCharsets)
    (java.nio.file Files)))
 
 (defn- ^HotSpotDiagnosticMXBean hotspot-diagnostic []
@@ -29,3 +32,23 @@
       (finally
         (io/delete-file path true)
         (io/delete-file (.toFile temp-dir) true)))))
+
+(deftest heapdump-history-roundtrip
+  (let [db (atom {})]
+    (with-redefs [storage/get-all-keys (fn
+                                         ([] (storage/get-all-keys nil))
+                                         ([prefix]
+                                          (filter #(clojure.string/starts-with? % prefix)
+                                                  (keys @db))))
+                  storage/load-bytes (fn [k] (get @db k))
+                  storage/save-bytes (fn [k v] (swap! db assoc k v))]
+      (let [entry-1 {:name "a.hprof" :created-at 1700000000000 :stats "stats-a"}
+            entry-2 {:name "b.hprof" :created-at 1700000001000 :stats "stats-b"}
+            bytes-1 (.getBytes (json/write-str entry-1) StandardCharsets/UTF_8)
+            bytes-2 (.getBytes (json/write-str entry-2) StandardCharsets/UTF_8)]
+        (storage/save-bytes "meta-heapdump-history/1700000000000|a.hprof" bytes-1)
+        (storage/save-bytes "meta-heapdump-history/1700000001000|b.hprof" bytes-2)
+        (let [history (heapdump/load-heapdump-history)]
+          (is (= 2 (count history)))
+          (is (= "b.hprof" (:name (first history))))
+          (is (= "stats-a" (:stats (second history)))))))))


### PR DESCRIPTION
### Motivation
- Persist results of `heapdump-stats` so previously analyzed heap dumps can be inspected later via the UI. 
- Expose a simple history API for the UI to list saved heapdump stats by name and date. 

### Description
- Save and load heapdump stats to RocksDB under the `meta-heapdump-history/` prefix with keys of the form `meta-heapdump-history/<created-at>|<name>` and payload `{name, created-at, stats}`; implemented in `src/clj/jfr/heapdump.clj` with `save-heapdump-history!` and `load-heapdump-history`.
- Persist each uploaded heapdump result when handling uploads in `handle-heapdump-upload` (calls `save-heapdump-history!`).
- Add a new API endpoint `GET /api/history-heapdump-stats` that returns the saved history (added to `src/clj/jfr/core.clj`).
- Extend the heapdump UI (`resources/public/heapdump.html`) with a `history-heapdump-stats` panel that fetches the new API, shows file name + date, allows click-to-view a saved `stats` entry, and refreshes the list after successful uploads.

### Testing
- Ran environment preparation with `./prepare-env.sh` successfully.
- Ran the test suite with `clj -M:test` which completed; tests run: 16 tests / 42 assertions with `0 failures, 0 errors`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f810a1c7388327a60acb98877bcfd8)