### PR TITLE
Use GitHub Actions BuildKit cache backend for Docker builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 
-      - name: Cache Docker layers
-        uses: actions/cache@v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-cache-${{ hashFiles('Dockerfile') }}
-          restore-keys: |
-            buildx-cache-
-
       - name: Prepare Maven cache directory
         run: |
           mkdir -p ~/.m2 && tree $PWD/
@@ -43,20 +35,22 @@ jobs:
           fi
 
 
+      - name: Build CI image
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          target: clojure
+          load: true
+          tags: jfr-merger-ci:latest
+          cache-from: type=gha,scope=jfr-merger-ci
+          cache-to: type=gha,scope=jfr-merger-ci,mode=max
+
       - name: Run tests
-        env:
-          DOCKER_BUILDKIT: "1"
         run: |
-          docker buildx build \
-            --target clojure \
-            --load \
-            --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to type=local,dest=/tmp/.buildx-cache,mode=max \
-            -t jfr-merger-ci .
           docker run --rm \
             -v $HOME/.m2:/root/.m2 \
             -v $PWD:/tmp/sources \
-            jfr-merger-ci \
+            jfr-merger-ci:latest \
             /bin/bash -c "cp -r /tmp/sources/* /app/ && /app/clojure/bin/clojure -M:test"
 
       - name: Check Clojure cache after build


### PR DESCRIPTION
### Motivation
- The previous CI used a local `/tmp/.buildx-cache` restored via `actions/cache`, which did not integrate with BuildKit’s GitHub Actions backend and allowed repeated `dnf install` steps despite "Cache restored" logs.
- Using the official BuildKit `gha` backend ensures layer metadata is stored and reused correctly across workflow runs per Docker recommendations. 

### Description
- Remove the manual `actions/cache` step that restored `/tmp/.buildx-cache` and its local `buildx build --cache-from/--cache-to` usage. 
- Add a `Build CI image` step using `docker/build-push-action@v7.0.0` with `cache-from: type=gha` and `cache-to: type=gha,mode=max` so BuildKit uses the GitHub Actions cache backend. 
- Keep the image loaded locally with `load: true` and tag it `jfr-merger-ci:latest`, and update the test invocation to run that tagged image. 

### Testing
- Ran `./prepare-env.sh`, which completed successfully but emitted a non-fatal proxy warning during `apt-get` metadata fetch. 
- Ran the test suite with `clj -M:test`, which executed 18 tests and reported `0 failures, 0 errors`. 
- Validated the updated workflow YAML by loading it with Ruby (`ruby -e 'require "yaml"; YAML.load_file(...)'`), which parsed successfully.

------