### PR TITLE
Add temporal JFR problem detector

### DIFF
--- a/src/clj/jfr/detector/detector.clj
+++ b/src/clj/jfr/detector/detector.clj
@@ -2,7 +2,8 @@
   (:require [clojure.string :as str])
   (:import
    [jdk.jfr.consumer RecordingFile RecordedEvent RecordedFrame RecordedStackTrace]
-   [java.nio.file Paths]))
+   [java.nio.file Paths]
+   [java.time Instant]))
 
 ;; ----------------------------
 ;; 0) Helper utilities
@@ -223,3 +224,189 @@
                    :top-stacks stacks})))
          (sort-by :count >))))
 
+;; ----------------------------
+;; 4) Temporal problem detector
+;; ----------------------------
+
+(defn- event-timestamp-ms [^RecordedEvent e]
+  (.toEpochMilli (.getStartTime e)))
+
+(defn- event-duration-ms [^RecordedEvent e]
+  (let [duration (.getDuration e)]
+    (when (and duration (pos? (.toNanos duration)))
+      (max 1 (.toMillis duration)))))
+
+(defn- event-weight [^RecordedEvent e]
+  (or (event-duration-ms e)
+      (alloc-size e)
+      1))
+
+(defn- instant-string [timestamp-ms]
+  (str (Instant/ofEpochMilli (long timestamp-ms))))
+
+(defn- clamp [min-value max-value value]
+  (-> value (max min-value) (min max-value)))
+
+(defn- choose-bucket-ms [samples]
+  (let [timestamps (map :timestamp-ms samples)
+        start (apply min timestamps)
+        finish (apply max timestamps)
+        duration (max 1 (- finish start))]
+    (long (clamp 250 5000 (Math/ceil (/ duration 60.0))))))
+
+(defn- median [values]
+  (let [sorted-values (vec (sort values))
+        n (count sorted-values)]
+    (cond
+      (zero? n) 0
+      (odd? n) (nth sorted-values (quot n 2))
+      :else (/ (+ (nth sorted-values (dec (quot n 2)))
+                  (nth sorted-values (quot n 2)))
+               2.0))))
+
+(defn- stack-key [frames]
+  (vec (take 12 frames)))
+
+(defn- segment-buckets [bucket-indexes]
+  (let [sorted-indexes (sort bucket-indexes)]
+    (reduce (fn [segments idx]
+              (if-let [[start end] (peek segments)]
+                (if (<= (- idx end) 1)
+                  (conj (pop segments) [start idx])
+                  (conj segments [idx idx]))
+                [[idx idx]]))
+            []
+            sorted-indexes)))
+
+(defn- segment-range [recording-start-ms bucket-ms [start-bucket end-bucket]]
+  (let [start-ms (+ recording-start-ms (* start-bucket bucket-ms))
+        end-ms (+ recording-start-ms (* (inc end-bucket) bucket-ms))]
+    {:start-ms start-ms
+     :end-ms end-ms
+     :start (instant-string start-ms)
+     :end (instant-string end-ms)}))
+
+(defn- coefficient-of-variation [values]
+  (let [n (count values)
+        avg (when (pos? n) (/ (reduce + values) n))]
+    (if (and avg (pos? avg))
+      (let [variance (/ (reduce + (map #(let [delta (- % avg)] (* delta delta)) values)) n)]
+        (/ (Math/sqrt variance) avg))
+      0)))
+
+(defn- add-problem [problems problem-type confidence reason ranges stack score event-types]
+  (conj problems {:type problem-type
+                  :confidence confidence
+                  :reason reason
+                  :ranges ranges
+                  :stack stack
+                  :score score
+                  :event-types event-types}))
+
+(defn- stack-temporal-problems
+  [{:keys [recording-start-ms bucket-ms total-buckets min-score]} [stack samples]]
+  (let [bucketed (->> samples
+                      (group-by #(quot (- (:timestamp-ms %) recording-start-ms) bucket-ms))
+                      (map (fn [[idx xs]] [idx (reduce + (map :weight xs))]))
+                      (into {}))
+        bucket-values (vals bucketed)
+        active-buckets (keys bucketed)
+        total-score (reduce + bucket-values)
+        event-types (->> samples (map :event-type) frequencies (sort-by val >) (take 5) (mapv first))
+        baseline (max 1 (median bucket-values))
+        max-score (if (seq bucket-values) (apply max bucket-values) 0)
+        peak-threshold (max min-score (* 3 baseline))
+        active-segments (segment-buckets active-buckets)
+        coverage (/ (count active-buckets) (max 1 total-buckets))
+        gaps (->> active-segments (map first) (partition 2 1) (map (fn [[a b]] (- b a))) vec)]
+    (cond-> []
+      (>= max-score peak-threshold)
+      (add-problem :peak
+                   (min 1.0 (/ max-score (max 1.0 (* 5.0 baseline))))
+                   "A stack has a short bucket whose event weight is much higher than its normal bucket weight."
+                   (->> bucketed
+                        (filter (fn [[_ score]] (>= score peak-threshold)))
+                        (map first)
+                        segment-buckets
+                        (mapv #(segment-range recording-start-ms bucket-ms %)))
+                   stack
+                   max-score
+                   event-types)
+
+      (and (>= total-score min-score)
+           (>= coverage 0.7)
+           (>= (count active-buckets) 3))
+      (add-problem :constant
+                   (min 1.0 coverage)
+                   "The same stack is active in most time buckets, which can indicate a sustained hot path."
+                   [(segment-range recording-start-ms bucket-ms [(apply min active-buckets) (apply max active-buckets)])]
+                   stack
+                   total-score
+                   event-types)
+
+      (and (>= total-score min-score)
+           (>= (count active-segments) 3)
+           (< coverage 0.7)
+           (seq gaps)
+           (<= (coefficient-of-variation gaps) 0.35))
+      (add-problem :periodic
+                   (max 0.1 (- 1.0 (coefficient-of-variation gaps)))
+                   "The same stack appears in repeated bursts with a stable interval between bursts."
+                   (mapv #(segment-range recording-start-ms bucket-ms %) active-segments)
+                   stack
+                   total-score
+                   event-types))))
+
+(defn analyze-problem-samples
+  "Detect temporal problem shapes in already extracted event samples.
+
+  Each sample must contain :timestamp-ms and should contain :frames. :weight and
+  :event-type are optional. The detector classifies candidate stacks as :peak,
+  :periodic, or :constant and returns time ranges plus representative stacks."
+  [samples {:keys [bucket-ms top-problems min-score]
+            :or {top-problems 20 min-score 5}}]
+  (let [normalized (->> samples
+                        (keep (fn [{:keys [timestamp-ms frames weight event-type]}]
+                                (when (and timestamp-ms (seq frames))
+                                  {:timestamp-ms timestamp-ms
+                                   :frames (stack-key frames)
+                                   :weight (or weight 1)
+                                   :event-type (or event-type "unknown")}))))]
+    (if (seq normalized)
+      (let [recording-start-ms (apply min (map :timestamp-ms normalized))
+            recording-end-ms (apply max (map :timestamp-ms normalized))
+            bucket-ms (or bucket-ms (choose-bucket-ms normalized))
+            total-buckets (inc (quot (- recording-end-ms recording-start-ms) bucket-ms))]
+        (->> normalized
+             (group-by :frames)
+             (mapcat #(stack-temporal-problems {:recording-start-ms recording-start-ms
+                                                :bucket-ms bucket-ms
+                                                :total-buckets total-buckets
+                                                :min-score min-score}
+                                               %))
+             (sort-by (juxt (comp - :confidence) (comp - :score)))
+             (take top-problems)
+             vec))
+      [])))
+
+(defn event-samples
+  "Extract timestamped stack samples from a JFR file for temporal problem analysis."
+  [jfr-path]
+  (->> (jfr-events jfr-path)
+       (keep (fn [^RecordedEvent e]
+               (let [frames (vec (stack->strings e))]
+                 (when (seq frames)
+                   {:timestamp-ms (event-timestamp-ms e)
+                    :event-type (event-name e)
+                    :weight (event-weight e)
+                    :frames frames}))))
+       vec))
+
+(defn detect-problem-ranges
+  "Detect peak, periodic, and constant problem candidates in a JFR file.
+
+  Returns maps with :type, :ranges, :stack, :score, :confidence, and :event-types."
+  ([jfr-path]
+   (detect-problem-ranges jfr-path {}))
+  ([jfr-path options]
+   (analyze-problem-samples (event-samples jfr-path) options)))

--- a/src/clj/jfr/detector/report.clj
+++ b/src/clj/jfr/detector/report.clj
@@ -19,6 +19,44 @@
   (when (and started finished)
     (str (- finished started) " ms")))
 
+(defn- format-confidence [confidence]
+  (if (number? confidence)
+    (format "%.0f%%" (* 100 confidence))
+    "—"))
+
+(defn- range-item [{:keys [start end start-ms end-ms]}]
+  [:li.problem-range
+   [:time.problem-range-start (or start (str start-ms))]
+   [:span.problem-range-separator " → "]
+   [:time.problem-range-end (or end (str end-ms))]])
+
+(defn- problem-stack [frames]
+  [:ol.problem-stack-frames
+   (for [frame (or frames [])]
+     [:li.problem-stack-frame [:code.problem-stack-frame-code frame]])])
+
+(defn- problem-range-block [{:keys [type confidence reason ranges stack score event-types]}]
+  [:div.problem-range-block
+   [:div.problem-range-header
+    [:div.problem-range-title-row
+     [:span.problem-range-title (str/capitalize (name (keyword type)))]
+     [:span.problem-range-score (str "score: " score)]]
+    [:div.problem-range-meta
+     [:span.problem-range-meta-item (str "confidence: " (format-confidence confidence))]
+     (when (seq event-types)
+       [:span.problem-range-meta-item (str "events: " (str/join ", " event-types))])]]
+   [:p.problem-range-reason reason]
+   (when (seq ranges)
+     [:details.problem-ranges-list
+      [:summary "Time ranges (" (count ranges) ")"]
+      [:ul.problem-range-list
+       (for [range ranges]
+         (range-item range))]])
+   (when (seq stack)
+     [:details.problem-stack
+      [:summary "Stack trace"]
+      (problem-stack stack)])])
+
 (defn- issue-stack-item [[frames hits]]
   [:li.issue-stack-item
    (when hits
@@ -47,7 +85,7 @@
 
 (defn report-div
   "It takes a report map (from JSON) and returns a Hiccup tree with a single root <div>"
-  [{:keys [uuid status scheduled-at started-at finished-at hit-count summary] :as report}]
+  [{:keys [uuid status scheduled-at started-at finished-at hit-count summary problem-ranges] :as report}]
   [:div.profiler-report
    [:div.report-header
     [:div.report-title-row
@@ -63,6 +101,13 @@
         (str "Duration: " (format-duration-ms started-at finished-at))])
      [:span.report-meta-item (str "Findings: " (count summary) " pattern" (when (not= 1 (count summary)) "s"))]]]
    [:div.report-body
-    [:div.report-issues
+    (when (seq problem-ranges)
+      [:section.problem-ranges
+       [:h2.problem-ranges-heading "Potential problem ranges"]
+       [:p.problem-ranges-description "Temporal detector groups stack samples into peak, periodic, and constant patterns. Use these ranges as the first places to inspect in the heatmaps and flamegraphs."]
+       (for [problem problem-ranges]
+         (problem-range-block problem))])
+    [:section.report-issues
+     [:h2.report-issues-heading "Known bad stack patterns"]
      (for [issue summary]
        (issue-block issue))]]])

--- a/src/clj/jfr/service.clj
+++ b/src/clj/jfr/service.clj
@@ -115,6 +115,7 @@
            (let [hits (detector/detect-patterns {:jfr-path merged-path
                                                       :alloc-only? false})
                  summary (detector/summarize hits {:top-stacks 10})
+                 problem-ranges (detector/detect-problem-ranges merged-path {:top-problems 20})
                  finished-at (System/currentTimeMillis)
                  result {:uuid uuid
                          :status "done"
@@ -122,7 +123,8 @@
                          :started-at started-at
                          :finished-at finished-at
                          :hit-count (count hits)
-                         :summary summary}]
+                         :summary summary
+                         :problem-ranges problem-ranges}]
              (write-detector-result! uuid result)
              (log/info (str "Detector job completed for " uuid
                             " at " finished-at

--- a/test/jfr/detector_test.clj
+++ b/test/jfr/detector_test.clj
@@ -1,0 +1,49 @@
+(ns jfr.detector-test
+  (:require [clojure.test :refer :all]
+            [jfr.detector.detector :as detector]))
+
+(defn- sample
+  ([bucket stack]
+   (sample bucket stack 1))
+  ([bucket stack weight]
+   {:timestamp-ms (* bucket 1000)
+    :frames stack
+    :weight weight
+    :event-type "jdk.ExecutionSample"}))
+
+(deftest analyze-problem-samples-detects-peak-ranges
+  (let [stack ["app.Work.hot()" "app.Work.run()"]
+        samples (concat (map #(sample % stack) [0 1 2 3 4 5])
+                        [(sample 6 stack 20)
+                         (sample 10 ["app.Other.idle()"] 1)])
+        problems (detector/analyze-problem-samples samples {:bucket-ms 1000 :min-score 5})
+        peak (first (filter #(= :peak (:type %)) problems))]
+    (is (some? peak))
+    (is (= stack (:stack peak)))
+    (is (= [{:start-ms 6000
+             :end-ms 7000
+             :start "1970-01-01T00:00:06Z"
+             :end "1970-01-01T00:00:07Z"}]
+           (:ranges peak)))))
+
+(deftest analyze-problem-samples-detects-periodic-ranges
+  (let [stack ["app.Poller.poll()" "app.Poller.run()"]
+        samples (map #(sample % stack 2) [0 3 6 9])
+        problems (detector/analyze-problem-samples samples {:bucket-ms 1000 :min-score 5})
+        periodic (first (filter #(= :periodic (:type %)) problems))]
+    (is (some? periodic))
+    (is (= 4 (count (:ranges periodic))))
+    (is (= "The same stack appears in repeated bursts with a stable interval between bursts."
+           (:reason periodic)))))
+
+(deftest analyze-problem-samples-detects-constant-ranges
+  (let [stack ["app.Looper.loop()" "app.Looper.run()"]
+        samples (map #(sample % stack 1) (range 10))
+        problems (detector/analyze-problem-samples samples {:bucket-ms 1000 :min-score 5})
+        constant (first (filter #(= :constant (:type %)) problems))]
+    (is (some? constant))
+    (is (= [{:start-ms 0
+             :end-ms 10000
+             :start "1970-01-01T00:00:00Z"
+             :end "1970-01-01T00:00:10Z"}]
+           (:ranges constant)))))

--- a/test/jfr/report_test.clj
+++ b/test/jfr/report_test.clj
@@ -11,6 +11,14 @@
    :started-at 2
    :finished-at 3
    :hit-count 3832
+   :problem-ranges [{:type :periodic
+                     :confidence 0.95
+                     :reason "The same stack appears in repeated bursts with a stable interval between bursts."
+                     :ranges [{:start "2026-06-08T00:00:00Z"
+                               :end "2026-06-08T00:00:01Z"}]
+                     :stack ["demo.Work.run()"]
+                     :score 42
+                     :event-types ["jdk.ExecutionSample"]}]
    :summary [{:id 4
               :title "new SimpleDateFormat repeatedly"
               :advice "Switch to immutable java.time.DateTimeFormatter (thread-safe)."
@@ -34,4 +42,8 @@
     (testing "each frame is rendered as a code line"
       (is (str/includes? rendered-html "<code class=\"issue-stack-frame-code\">java.util.Arrays.copyOf")))
     (testing "hit counts are displayed next to the stack"
-      (is (str/includes? rendered-html "283 hits")))))
+      (is (str/includes? rendered-html "283 hits")))
+    (testing "temporal problem ranges are visible"
+      (is (str/includes? rendered-html "Potential problem ranges"))
+      (is (str/includes? rendered-html "Periodic"))
+      (is (str/includes? rendered-html "2026-06-08T00:00:00Z")))))


### PR DESCRIPTION
### Motivation
- Provide a temporal detector that analyzes JFR recordings to surface time ranges and representative stacks for likely problems, complementing existing bad-stack pattern matching. 
- Detect three temporal shapes — `:peak`, `:periodic`, and `:constant` — so users can quickly navigate to suspect time ranges in heatmaps/flamegraphs.

### Description
- Implemented a temporal detector in `src/clj/jfr/detector/detector.clj` that extracts timestamped stack samples (`event-samples`), groups stacks into time buckets, and classifies candidate stacks with `analyze-problem-samples` / `detect-problem-ranges` returning `:type`, `:ranges`, `:stack`, `:score`, `:confidence`, and `:event-types`.
- Added helper logic for bucketing, scoring and range formatting (median, CV, segment merging, bucket size heuristics) and small JVM/Instant utilities; also import `java.time.Instant` for human-readable times.
- Integrated temporal results into the detector job in `src/clj/jfr/service.clj` so detector outputs now include `:problem-ranges` alongside the existing `:summary` of pattern matches and are persisted via the same detector storage key.
- Extended HTML reporting in `src/clj/jfr/detector/report.clj` to render a new “Potential problem ranges” section (ranges, confidence, score, event types and representative stacks), and added unit tests under `test/jfr/detector_test.clj` and updated `test/jfr/report_test.clj` to cover the new behavior.

### Testing
- Ran the test suite with `clj -M:test`, which executed the project tests including the new `jfr.detector-test` and updated `jfr.report-test` and completed successfully. 
- Test summary: `Ran 24 tests containing 70 assertions.` and `0 failures, 0 errors` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26741fe04883279ea74a3edc8b4309)